### PR TITLE
Add unit tests for message formatting in UI

### DIFF
--- a/src/frontend/chat_mode/message_formatting.rs
+++ b/src/frontend/chat_mode/message_formatting.rs
@@ -1,4 +1,5 @@
-use ratatui::prelude::*;
+use ratatui::text::{Line, Span, Text};
+use ratatui::style::{Style, Color, Modifier};
 
 use crate::{
     chat::Chat,
@@ -129,3 +130,58 @@ fn format_tool_call(tool_call: &swiftide::chat_completion::ToolCall) -> String {
         formatted_args
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::text::{Line, Span};
+    
+    #[test]
+    fn test_format_chat_message_user_role() {
+        let message = ChatMessage::new_user("Hello, user!").build();
+        let chat = Chat::default();
+        
+        let formatted_text = format_chat_message(&chat, &message);
+        
+        assert!(formatted_text
+            .lines
+            .first()
+            .map(|line| line.spans.first())
+            .flatten()
+            .map(|span| span.style == message_styles::USER)
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn test_format_chat_message_system_role() {
+        let message = ChatMessage::new_system("System message!").build();
+        let chat = Chat::default();
+        
+        let formatted_text = format_chat_message(&chat, &message);
+        
+        assert!(formatted_text
+            .lines
+            .first()
+            .map(|line| line.spans.first())
+            .flatten()
+            .map(|span| span.style == message_styles::SYSTEM)
+            .unwrap_or(false));
+    }
+
+    #[test]
+    fn test_format_chat_message_assistant_role() {
+        let message = ChatMessage::new_assistant("Here is a response with an assistant.").build();
+        let chat = Chat::default();
+        
+        let formatted_text = format_chat_message(&chat, &message);
+        
+        assert!(formatted_text
+            .lines
+            .first()
+            .map(|line| line.spans.first())
+            .flatten()
+            .map(|span| span.style == message_styles::ASSISTANT)
+            .unwrap_or(false));
+    }
+}
+


### PR DESCRIPTION
This pull request includes the addition of unit tests for message formatting in the UI components. Specifically, it targets functions involved in rendering chat messages with appropriate styles based on role distinctions like User, Assistant, and System. 

Adjustments were made to import statements and test assertions to align with the current codebase implementation and ensure correct styling using the ratatui framework.