### PR TITLE
fix: Container can be both exiting and removing in tests

### DIFF
--- a/src/agent/docker_tool_executor.rs
+++ b/src/agent/docker_tool_executor.rs
@@ -493,9 +493,11 @@ mod tests {
 
         // assert it stopped
         let container = docker.inspect_container(&container_id, None).await.unwrap();
-        assert_eq!(
-            container.state.as_ref().unwrap().status,
-            Some(ContainerStateStatusEnum::REMOVING)
+        let status = container.state.as_ref().unwrap().status;
+        assert!(
+            status == Some(ContainerStateStatusEnum::REMOVING) ||
+            status == Some(ContainerStateStatusEnum::EXITED),
+            "Unexpected container state: {:?}", status
         );
     }
 

--- a/src/agent/docker_tool_executor.rs
+++ b/src/agent/docker_tool_executor.rs
@@ -495,9 +495,10 @@ mod tests {
         let container = docker.inspect_container(&container_id, None).await.unwrap();
         let status = container.state.as_ref().unwrap().status;
         assert!(
-            status == Some(ContainerStateStatusEnum::REMOVING) ||
-            status == Some(ContainerStateStatusEnum::EXITED),
-            "Unexpected container state: {:?}", status
+            status == Some(ContainerStateStatusEnum::REMOVING)
+                || status == Some(ContainerStateStatusEnum::EXITED),
+            "Unexpected container state: {:?}",
+            status
         );
     }
 


### PR DESCRIPTION
PR created by kwaak, but PR body too big

Feedback: Seems it didn't run rustfmt