### PR TITLE
feat: Make `otel` Feature Contingent on Feature Flag and Configuration

### DIFF
--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -61,7 +61,7 @@ pub struct Config {
 }
 
 fn default_otel_enabled() -> bool {
-    true
+    false
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize, Default)]
@@ -193,7 +193,7 @@ mod tests {
         }
 
         // Verify default otel_enabled
-        assert!(config.otel_enabled);
+        assert!(!config.otel_enabled);
     }
 
     #[test]
@@ -273,6 +273,6 @@ mod tests {
         }
 
         // Verify default otel_enabled
-        assert!(config.otel_enabled);
+        assert!(!config.otel_enabled);
     }
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -54,6 +54,14 @@ pub struct Config {
     /// WARN: There currently is _no_ limit for endless mode
     #[serde(default)]
     pub endless_mode: bool,
+
+    /// OpenTelemetry tracing feature toggle
+    #[serde(default = "default_otel_enabled")]
+    pub otel_enabled: bool,
+}
+
+fn default_otel_enabled() -> bool {
+    true
 }
 
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize, Default)]
@@ -167,7 +175,6 @@ mod tests {
             provider = "OpenAI"
             api_key = "text:test-key"
             prompt_model = "gpt-4o-mini"
-
             "#;
 
         let config: Config = toml::from_str(toml).unwrap();
@@ -184,6 +191,9 @@ mod tests {
         } else {
             panic!("Expected single OpenAI configuration");
         }
+
+        // Verify default otel_enabled
+        assert!(config.otel_enabled);
     }
 
     #[test]
@@ -261,5 +271,8 @@ mod tests {
         } else {
             panic!("Expected multiple LLM configurations");
         }
+
+        // Verify default otel_enabled
+        assert!(config.otel_enabled);
     }
 }

--- a/src/kwaak_tracing.rs
+++ b/src/kwaak_tracing.rs
@@ -61,7 +61,7 @@ pub fn init(repository: &Repository) -> Result<Guard> {
     ];
 
     let mut provider_for_guard = None;
-    if cfg!(feature = "otel") {
+    if cfg!(feature = "otel") && repository.config().otel_enabled {
         dbg!("OpenTelemetry tracing enabled");
         let provider = init_otel();
         let tracer = provider.tracer("kwaak");


### PR DESCRIPTION
### Changes Made:
- Updated the `Config` struct in `src/config/config.rs` to include a new field `otel_enabled`.
- Modified logic in `src/kwaak_tracing.rs` to enable OpenTelemetry tracing based on both a feature flag and the `otel_enabled` configuration setting.
- Changed the default value of `otel_enabled` to `false`.
- Updated deserialization tests in `src/config/config.rs` to reflect this change.
- Ensured all tests pass successfully after the modifications.

---

_This pull request was created by [kwaak](https://github.com/bosun-ai/kwaak), a free, open-source, autonomous coding agent tool. Pull requests are tracked in bosun-ai/kwaak#48_

