### PR TITLE
feat: Add /delete_chat command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -213,7 +213,7 @@ impl CommandHandler {
                 let this_handler = Arc::clone(&this_handler);
 
                 joinset.spawn(async move {
-                    let result = this_handler.handle_command(&repository, &ui_tx, &cmd).await;
+                    let result = this_handler.handle_command(&repository,  &cmd).await;
                     ui_tx.send(UIEvent::CommandDone(cmd.uuid())).unwrap();
 
                     if let Err(error) = result {
@@ -239,76 +239,45 @@ impl CommandHandler {
     /// TODO: Most commands should probably be handled in a tokio task
     /// Maybe generalize tasks to make ui updates easier?
     #[tracing::instrument(skip_all, fields(otel.name = %cmd.to_string(), uuid = %cmd.uuid()), err)]
-    async fn handle_command(
-        &self,
-        repository: &Repository,
-        ui_tx: &mpsc::UnboundedSender<UIEvent>,
-        cmd: &Command,
-    ) -> Result<()> {
+    async fn handle_command(&self, repository: &Repository, cmd: &Command) -> Result<()> {
         let now = std::time::Instant::now();
         tracing::warn!("Handling command {cmd}");
 
         #[allow(clippy::match_wildcard_for_single_variants)]
         match cmd {
-            Command::StopAgent { uuid } => {
-                let mut locked_agents = self.agents.write().await;
-                let Some(agent) = locked_agents.get_mut(uuid) else {
-                    let _ = ui_tx.send(
-                        ChatMessage::new_system("No agent found (yet), is it starting up?")
-                            .uuid(*uuid)
-                            .into(),
-                    );
-                    return Ok(());
-                };
-
-                let _ = ui_tx.send(
-                    ChatMessage::new_system("Agent will finish its current completions and stop")
-                        .uuid(*uuid)
-                        .into(),
-                );
-
-                // TODO: Concerned this might not work as expected, since the agent also runs as
-                // &mut. It 'seems' to work, but I'm not sure if it's correct.
-                agent.stop().await;
+            Command::StopAgent { uuid } => self.stop_agent(*uuid).await?,
+            Command::DeleteChat { uuid } => {
+                self.stop_agent(*uuid).await?;
+                self.send_ui_event(UIEvent::ChatDeleted(*uuid));
             }
             Command::IndexRepository { .. } => {
                 let (command_responder, _guard) = self.spawn_command_responder(&cmd.uuid());
                 indexing::index_repository(repository, Some(command_responder)).await?;
             }
             Command::ShowConfig { uuid } => {
-                ui_tx
-                    .send(
-                        ChatMessage::new_system(toml::to_string_pretty(repository.config())?)
-                            .uuid(*uuid)
-                            .to_owned()
-                            .into(),
-                    )
-                    .unwrap();
+                self.send_ui_event(
+                    ChatMessage::new_system(toml::to_string_pretty(repository.config())?)
+                        .uuid(*uuid)
+                        .to_owned(),
+                );
             }
             Command::Chat { uuid, ref message } => {
                 let agent = self.find_or_start_agent_by_uuid(*uuid, message).await?;
 
                 agent.query(message).await?;
             }
-            Command::DeleteChat { uuid } => {
-                let _ = ui_tx.send(UIEvent::ChatDeleted(*uuid));
-                // Logic to actually delete the chat from the `App` state can be added here.
-            }
             Command::Quit { .. } => unreachable!("Quit should be handled earlier"),
         }
         // Sleep for a tiny bit to avoid racing with agent responses
         tokio::time::sleep(Duration::from_millis(50)).await;
         let elapsed = now.elapsed();
-        ui_tx
-            .send(
-                ChatMessage::new_system(format!(
-                    "Command {cmd} successful in {} seconds",
-                    elapsed.as_secs_f64().round()
-                ))
-                .uuid(cmd.uuid())
-                .into(),
-            )
-            .unwrap();
+        self.send_ui_event(
+            ChatMessage::new_system(format!(
+                "Command {cmd} successful in {} seconds",
+                elapsed.as_secs_f64().round()
+            ))
+            .uuid(cmd.uuid()),
+        );
 
         Ok(())
     }
@@ -331,6 +300,30 @@ impl CommandHandler {
         self.agents.write().await.insert(uuid, running_agent);
 
         Ok(cloned)
+    }
+
+    async fn stop_agent(&self, uuid: Uuid) -> Result<()> {
+        let mut locked_agents = self.agents.write().await;
+        let Some(agent) = locked_agents.get_mut(&uuid) else {
+            self.send_ui_event(
+                ChatMessage::new_system("No agent found (yet), is it starting up?").uuid(uuid),
+            );
+            return Ok(());
+        };
+
+        self.send_ui_event(
+            ChatMessage::new_system("Agent will finish its current completions and stop")
+                .uuid(uuid),
+        );
+
+        agent.stop().await;
+        Ok(())
+    }
+
+    // Try to send a UI event, ignore if the UI is not connected
+    fn send_ui_event(&self, event: impl Into<UIEvent>) {
+        let Some(ui_tx) = &self.ui_tx else { return };
+        let _ = ui_tx.send(event.into());
     }
 
     /// Forwards updates from the backend (i.e. agents) to the UI

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -36,6 +36,7 @@ pub enum Command {
     IndexRepository { uuid: Uuid },
     StopAgent { uuid: Uuid },
     Chat { uuid: Uuid, message: String },
+    DeleteChat { uuid: Uuid },
 }
 
 pub enum CommandResponse {
@@ -117,7 +118,8 @@ impl Command {
             | Command::StopAgent { uuid }
             | Command::ShowConfig { uuid }
             | Command::IndexRepository { uuid }
-            | Command::Chat { uuid, .. } => *uuid,
+            | Command::Chat { uuid, .. }
+            | Command::DeleteChat { uuid } => *uuid,
         }
     }
 
@@ -128,6 +130,7 @@ impl Command {
             Command::ShowConfig { .. } => Command::ShowConfig { uuid },
             Command::IndexRepository { .. } => Command::IndexRepository { uuid },
             Command::Chat { message, .. } => Command::Chat { uuid, message },
+            Command::DeleteChat { .. } => Command::DeleteChat { uuid },
         }
     }
 }
@@ -286,6 +289,10 @@ impl CommandHandler {
                 let agent = self.find_or_start_agent_by_uuid(*uuid, message).await?;
 
                 agent.query(message).await?;
+            }
+            Command::DeleteChat { uuid } => {
+                let _ = ui_tx.send(UIEvent::ChatDeleted(*uuid));
+                // Logic to actually delete the chat from the `App` state can be added here.
             }
             Command::Quit { .. } => unreachable!("Quit should be handled earlier"),
         }

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -293,6 +293,15 @@ impl App<'_> {
                         });
                         self.change_mode(AppMode::Quit);
                     }
+                    UIEvent::ChatDeleted(uuid) => {
+                        // Remove the chat with the given UUID
+                        self.chats.retain(|chat| chat.uuid != uuid);
+                        // Select the first chat if available
+                        if !self.chats.is_empty() {
+                            self.current_chat = self.chats[0].uuid;
+                        }
+                        self.chats_state.select(Some(0));
+                    }
                 }
             }
         }

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -195,7 +195,9 @@ impl App<'_> {
 
     #[tracing::instrument(skip(self))]
     pub fn dispatch_command(&mut self, cmd: &Command) {
-        self.current_chat_mut().transition(ChatState::Loading);
+        if let Some(chat) = self.current_chat_mut() {
+            chat.transition(ChatState::Loading);
+        }
 
         self.command_tx
             .as_ref()
@@ -208,8 +210,9 @@ impl App<'_> {
         if message.uuid() == Some(self.boot_uuid) {
             return;
         }
-        let chat = self.find_chat_mut(message.uuid().unwrap_or(self.current_chat));
-        chat.add_message(message);
+        if let Some(chat) = self.find_chat_mut(message.uuid().unwrap_or(self.current_chat)) {
+            chat.add_message(message);
+        }
     }
 
     #[tracing::instrument(skip_all)]
@@ -264,17 +267,18 @@ impl App<'_> {
                     UIEvent::CommandDone(uuid) => {
                         if uuid == self.boot_uuid {
                             has_indexed_on_boot = true;
-                            self.current_chat_mut().transition(ChatState::Ready);
-                        } else {
-                            self.find_chat_mut(uuid).transition(ChatState::Ready);
+                            self.current_chat_mut()
+                                .expect("Boot uuid should always be present")
+                                .transition(ChatState::Ready);
+                        } else if let Some(chat) = self.find_chat_mut(uuid) {
+                            chat.transition(ChatState::Ready);
                         }
                     }
                     UIEvent::ActivityUpdate(uuid, activity) => {
                         if uuid == self.boot_uuid {
                             splash.set_message(activity);
-                        } else {
-                            self.find_chat_mut(uuid)
-                                .transition(ChatState::LoadingWithMessage(activity));
+                        } else if let Some(chat) = self.find_chat_mut(uuid) {
+                            chat.transition(ChatState::LoadingWithMessage(activity));
                         }
                     }
                     UIEvent::ChatMessage(message) => {
@@ -294,13 +298,22 @@ impl App<'_> {
                         self.change_mode(AppMode::Quit);
                     }
                     UIEvent::ChatDeleted(uuid) => {
+                        self.dispatch_command(&Command::StopAgent { uuid });
                         // Remove the chat with the given UUID
                         self.chats.retain(|chat| chat.uuid != uuid);
-                        // Select the first chat if available
-                        if !self.chats.is_empty() {
-                            self.current_chat = self.chats[0].uuid;
+
+                        if self.chats.is_empty() {
+                            self.add_chat(Chat::default());
+                            self.chats_state.select(Some(0));
+                            self.add_chat_message(
+                                ChatMessage::new_system(
+                                    "Nice, you managed to delete the last chat!",
+                                )
+                                .build(),
+                            );
+                        } else {
+                            self.next_chat();
                         }
-                        self.chats_state.select(Some(0));
                     }
                 }
             }
@@ -313,25 +326,19 @@ impl App<'_> {
         Ok(())
     }
 
-    fn find_chat_mut(&mut self, uuid: Uuid) -> &mut Chat {
-        self.chats
-            .iter_mut()
-            .find(|chat| chat.uuid == uuid)
-            .unwrap_or_else(|| panic!("Could not find chat for {uuid}"))
+    fn find_chat_mut(&mut self, uuid: Uuid) -> Option<&mut Chat> {
+        self.chats.iter_mut().find(|chat| chat.uuid == uuid)
     }
 
-    fn find_chat(&self, uuid: Uuid) -> &Chat {
-        self.chats
-            .iter()
-            .find(|chat| chat.uuid == uuid)
-            .unwrap_or_else(|| panic!("Could not find chat for {uuid}"))
+    fn find_chat(&self, uuid: Uuid) -> Option<&Chat> {
+        self.chats.iter().find(|chat| chat.uuid == uuid)
     }
 
-    pub(crate) fn current_chat(&self) -> &Chat {
+    pub(crate) fn current_chat(&self) -> Option<&Chat> {
         self.find_chat(self.current_chat)
     }
 
-    pub(crate) fn current_chat_mut(&mut self) -> &mut Chat {
+    pub(crate) fn current_chat_mut(&mut self) -> Option<&mut Chat> {
         self.find_chat_mut(self.current_chat)
     }
 

--- a/src/frontend/chat_mode/on_key.rs
+++ b/src/frontend/chat_mode/on_key.rs
@@ -61,7 +61,9 @@ pub fn on_key(app: &mut App, key: KeyEvent) {
     match key.code {
         KeyCode::Tab => app.send_ui_event(UIEvent::NextChat),
         KeyCode::End => {
-            let current_chat = app.current_chat_mut();
+            let Some(current_chat) = app.current_chat_mut() else {
+                return;
+            };
             let num_lines = current_chat.num_lines;
 
             current_chat.vertical_scroll = num_lines;
@@ -69,14 +71,18 @@ pub fn on_key(app: &mut App, key: KeyEvent) {
                 current_chat.vertical_scroll_state.position(num_lines);
         }
         KeyCode::PageDown => {
-            let current_chat = app.current_chat_mut();
+            let Some(current_chat) = app.current_chat_mut() else {
+                return;
+            };
             current_chat.vertical_scroll = current_chat.vertical_scroll.saturating_add(1);
             current_chat.vertical_scroll_state = current_chat
                 .vertical_scroll_state
                 .position(current_chat.vertical_scroll);
         }
         KeyCode::PageUp => {
-            let current_chat = app.current_chat_mut();
+            let Some(current_chat) = app.current_chat_mut() else {
+                return;
+            };
             current_chat.vertical_scroll = current_chat.vertical_scroll.saturating_sub(1);
             current_chat.vertical_scroll_state = current_chat
                 .vertical_scroll_state

--- a/src/frontend/chat_mode/ui.rs
+++ b/src/frontend/chat_mode/ui.rs
@@ -65,7 +65,9 @@ pub fn ui(f: &mut ratatui::Frame, area: Rect, app: &mut App) {
 }
 
 fn render_chat_messages(f: &mut ratatui::Frame, app: &mut App, area: Rect) {
-    let current_chat = app.current_chat_mut();
+    let Some(current_chat) = app.current_chat_mut() else {
+        return;
+    };
     let messages = current_chat.messages.clone();
     let chat_content: Text = messages
         .iter()
@@ -169,8 +171,8 @@ fn render_input_bar(f: &mut ratatui::Frame, app: &mut App, area: Rect) {
         .padding(Padding::horizontal(1))
         .borders(Borders::ALL);
 
-    if app.current_chat().is_loading() {
-        let loading_msg = match &app.current_chat().state {
+    if app.current_chat().is_some_and(Chat::is_loading) {
+        let loading_msg = match &app.current_chat().expect("infallible").state {
             ChatState::Loading => "Kwaaking ...".to_string(),
             ChatState::LoadingWithMessage(msg) => format!("Kwaaking ({msg}) ..."),
             ChatState::Ready => unreachable!(),

--- a/src/frontend/ui_command.rs
+++ b/src/frontend/ui_command.rs
@@ -22,6 +22,7 @@ pub enum UserInputCommand {
     IndexRepository,
     NextChat,
     NewChat,
+    DeleteChat,
 }
 
 impl UserInputCommand {
@@ -30,6 +31,7 @@ impl UserInputCommand {
             UserInputCommand::Quit => Some(Command::Quit { uuid }),
             UserInputCommand::ShowConfig => Some(Command::ShowConfig { uuid }),
             UserInputCommand::IndexRepository => Some(Command::IndexRepository { uuid }),
+            UserInputCommand::DeleteChat => Some(Command::DeleteChat { uuid }),
             _ => None,
         }
     }
@@ -59,6 +61,7 @@ mod tests {
             ("/index_repository", UserInputCommand::IndexRepository),
             ("/next_chat", UserInputCommand::NextChat),
             ("/new_chat", UserInputCommand::NewChat),
+            ("/delete_chat", UserInputCommand::DeleteChat),
         ];
 
         for (input, expected_command) in test_cases {

--- a/src/frontend/ui_event.rs
+++ b/src/frontend/ui_event.rs
@@ -27,6 +27,8 @@ pub enum UIEvent {
     ActivityUpdate(Uuid, String),
     /// Quit from the frontend
     Quit,
+    /// Chat deleted
+    ChatDeleted(Uuid),
 }
 
 impl From<ChatMessage> for UIEvent {


### PR DESCRIPTION
This pull request introduces the `/delete_chat` command to the kwaak project, enabling users to delete specific chats within the application. Key changes include:

- Updated the `Command` enum in `src/commands.rs` to include the `DeleteChat` variant.
- Added support for parsing the `/delete_chat` command in `src/frontend/ui_command.rs`.
- Implemented handling for `UIEvent::ChatDeleted` in `src/frontend/app.rs`.
- All tests passed successfully with no regressions.

Further improvements and tests are recommended for areas with low coverage.

---

_This pull request was created by [kwaak](https://github.com/bosun-ai/kwaak), a free, open-source, autonomous coding agent tool. Pull requests are tracked in bosun-ai/kwaak#48_

