### PR TITLE
fix: truncate chat titles to 30 characters in rename_chat function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2173,6 +2173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,6 +2418,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs4"
@@ -3440,6 +3452,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "swiftide",
+ "swiftide-core",
  "swiftide-docker-executor",
  "swiftide-macros",
  "tavily",
@@ -4217,6 +4230,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9366861eb2a2c436c20b12c8dbec5f798cea6b47ad99216be0282942e2c81ea0"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
 ]
 
 [[package]]
@@ -6385,9 +6424,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868fc2689bf89b9d8e993f4855f9d806fd753ae5b314fd286c55512a62b881e6"
+checksum = "2bf8835344bcf209b54540646d95d83126bc062afa8622c9c58d646b9700c34b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6396,7 +6435,9 @@ dependencies = [
  "futures-util",
  "itertools 0.13.0",
  "lazy_static",
+ "mockall",
  "pin-project",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6345,9 +6345,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "369374104ed455334bd862ebd01f7861de14057ddc96cdbcaece754d2493293d"
+checksum = "1920b84f38e44bc31cd38d2b4c381738c0b2451eef41d0dd44cf6e1f307c2a51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6494,9 +6494,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "840c51b76e2d2c27d0e715b4bdd83f952c3b5d39a36dc630422c6b0787ee02c6"
+checksum = "e3f90b4918b2e0adc0948c0b040f71157dd333a26a472f7d07594e06529bf3f7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ insta = "1.41.1"
 tempfile = "3.15.0"
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
+swiftide-core = { version = "0.16.1", features = ["test-utils"] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.42.0", features = ["full"] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
 swiftide-docker-executor = "0.1.1"
-swiftide = { version = "0.16.0", features = [
+swiftide = { version = "0.16.1", features = [
   "lancedb",
   "openai",
   "tree-sitter",
@@ -27,7 +27,7 @@ swiftide = { version = "0.16.0", features = [
   "swiftide-agents",
 
 ] }
-swiftide-macros = { version = "0.16.0" }
+swiftide-macros = { version = "0.16.1" }
 toml = "0.8.19"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -283,7 +283,7 @@ async fn rename_chat(
         .context("Could not get chat name")?
         .trim_matches('"')
         .chars()
-        .take(30) 
+        .take(30)
         .collect::<String>();
 
     command_responder.send_rename(chat_name);

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -148,7 +148,7 @@ pub async fn build_agent(
                     .await;
 
                 let top_level_project_overview = context.exec_cmd(&Command::shell("fd -d2")).await?.output;
-                context.add_message(chat_completion::ChatMessage::new_user(format!("The following is a max depth 2, high level overview of the directory structure of the project: \n ```{top_level_project_overview}```"))).await;
+                context.add_message(chat_completion::ChatMessage::new_user(format!("The following is a max depth 2, high level overview of the directory structure of the project: \n ```{top_level_project_overview}```")).await;
 
                 Ok(())
             })
@@ -276,13 +276,15 @@ async fn rename_chat(
 ) -> Result<()> {
     let chat_name = fast_query_provider
         .prompt(
-            format!("Give a good, short, max 20 chars title for the following query:\n{query}")
+            format!("Give a good, short, max 100 chars title for the following query:\n{query}")
                 .into(),
         )
         .await
         .context("Could not get chat name")?
         .trim_matches('"')
-        .to_string();
+        .chars()
+        .take(100) // Take only the first 100 characters
+        .collect::<String>();
 
     command_responder.send_rename(chat_name);
 

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -303,16 +303,20 @@ mod tests {
     async fn test_rename_chat() {
         let query = "This is a query";
         let mut llm_mock = MockSimplePrompt::new();
-        llm_mock.expect_prompt().returning(|_| Ok("Excellent title".to_string()));
+        llm_mock
+            .expect_prompt()
+            .returning(|_| Ok("Excellent title".to_string()));
 
         let mut command_responder = CommandResponder::default();
 
-        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder).await.unwrap();
+        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder)
+            .await
+            .unwrap();
 
         let message = command_responder.recv().await.unwrap();
 
         match message {
-            CommandResponse::RenameChat(_, msg) => assert_eq!(msg,"Excellent title"),
+            CommandResponse::RenameChat(_, msg) => assert_eq!(msg, "Excellent title"),
             _ => panic!("Expected RenameChat"),
         }
     }
@@ -321,11 +325,15 @@ mod tests {
     async fn test_rename_chat_limits_60() {
         let query = "This is a query";
         let mut llm_mock = MockSimplePrompt::new();
-        llm_mock.expect_prompt().returning(|_| Ok("Excellent title".repeat(100).to_string()));
+        llm_mock
+            .expect_prompt()
+            .returning(|_| Ok("Excellent title".repeat(100).to_string()));
 
         let mut command_responder = CommandResponder::default();
 
-        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder).await.unwrap();
+        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder)
+            .await
+            .unwrap();
 
         let message = command_responder.recv().await.unwrap();
 

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -276,17 +276,62 @@ async fn rename_chat(
 ) -> Result<()> {
     let chat_name = fast_query_provider
         .prompt(
-            format!("Give a good, short, max 100 chars title for the following query:\n{query}")
+            format!("Give a good, short, max 60 chars title for the following query. Only respond with the title.:\n{query}")
                 .into(),
         )
         .await
         .context("Could not get chat name")?
         .trim_matches('"')
         .chars()
-        .take(100) // Take only the first 100 characters
+        .take(30) 
         .collect::<String>();
 
     command_responder.send_rename(chat_name);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use swiftide_core::MockSimplePrompt;
+
+    use crate::commands::CommandResponse;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_rename_chat() {
+        let query = "This is a query";
+        let mut llm_mock = MockSimplePrompt::new();
+        llm_mock.expect_prompt().returning(|_| Ok("Excellent title".to_string()));
+
+        let mut command_responder = CommandResponder::default();
+
+        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder).await.unwrap();
+
+        let message = command_responder.recv().await.unwrap();
+
+        match message {
+            CommandResponse::RenameChat(_, msg) => assert_eq!(msg,"Excellent title"),
+            _ => panic!("Expected RenameChat"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_rename_chat_limits_60() {
+        let query = "This is a query";
+        let mut llm_mock = MockSimplePrompt::new();
+        llm_mock.expect_prompt().returning(|_| Ok("Excellent title".repeat(100).to_string()));
+
+        let mut command_responder = CommandResponder::default();
+
+        rename_chat(&query, &llm_mock as &dyn SimplePrompt, &command_responder).await.unwrap();
+
+        let message = command_responder.recv().await.unwrap();
+
+        match message {
+            CommandResponse::RenameChat(_, msg) => assert_eq!(msg.len(), 30),
+            _ => panic!("Expected RenameChat"),
+        }
+    }
 }

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -148,7 +148,7 @@ pub async fn build_agent(
                     .await;
 
                 let top_level_project_overview = context.exec_cmd(&Command::shell("fd -d2")).await?.output;
-                context.add_message(chat_completion::ChatMessage::new_user(format!("The following is a max depth 2, high level overview of the directory structure of the project: \n ```{top_level_project_overview}```")).await;
+                context.add_message(chat_completion::ChatMessage::new_user(format!("The following is a max depth 2, high level overview of the directory structure of the project: \n ```{top_level_project_overview}```"))).await;
 
                 Ok(())
             })

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -39,6 +39,7 @@ pub enum Command {
     DeleteChat { uuid: Uuid },
 }
 
+#[derive(Debug, Clone)]
 pub enum CommandResponse {
     Chat(ChatMessage),
     ActivityUpdate(Uuid, String),


### PR DESCRIPTION
Ensure the `rename_chat` function truncates chat titles to a maximum of 30 characters. This adjustment helps avoid any potential issues with chat title length in the application.

---

_This pull request was created by [kwaak](https://github.com/bosun-ai/kwaak), a free, open-source, autonomous coding agent tool. Pull requests are tracked in bosun-ai/kwaak#48_

