### PR TITLE
refactor: Rework command handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,6 +3531,7 @@ dependencies = [
  "lancedb",
  "lazy_static",
  "log",
+ "mockall",
  "num_cpus",
  "octocrab",
  "openssl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ swiftide = { version = "0.16.4", features = [
   "swiftide-agents",
 
 ] }
+swiftide-core = { version = "0.16.4" }
 swiftide-macros = { version = "0.16.4" }
 toml = "0.8.19"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ tempfile = "3.15.0"
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
 swiftide-core = { version = "0.16.1", features = ["test-utils"] }
+mockall = "0.13.1"
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ missing_errors_doc = "allow"
 
 [features]
 default = ["otel"]
-"test-layout" = []
 "otel" = [
   "dep:tracing-opentelemetry",
   "dep:opentelemetry_sdk",

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -307,7 +307,7 @@ async fn rename_chat(
         .context("Could not get chat name")?
         .trim_matches('"')
         .chars()
-        .take(30)
+        .take(60)
         .collect::<String>();
 
     command_responder.rename(&chat_name);
@@ -320,7 +320,7 @@ mod tests {
     use swiftide_core::MockSimplePrompt;
 
     use crate::commands::MockResponder;
-    use mockall::predicate::*;
+    use mockall::{predicate, PredicateBooleanExt};
 
     use super::*;
 
@@ -336,8 +336,9 @@ mod tests {
 
         mock_responder
             .expect_rename()
-            .with(eq("Excellent title"))
-            .once();
+            .with(predicate::eq("Excellent title"))
+            .once()
+            .returning(|_| ());
 
         rename_chat(&query, &llm_mock as &dyn SimplePrompt, &mock_responder)
             .await
@@ -356,8 +357,12 @@ mod tests {
 
         mock_responder
             .expect_rename()
-            .with(eq("Excellent title"))
-            .once();
+            .with(
+                predicate::str::starts_with("Excellent title")
+                    .and(predicate::function(|s: &str| s.len() == 60)),
+            )
+            .once()
+            .returning(|_| ());
 
         rename_chat(&query, &llm_mock as &dyn SimplePrompt, &mock_responder)
             .await

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -88,3 +88,77 @@ impl Default for Chat {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use swiftide::chat_completion;
+
+    use super::*;
+    use crate::chat_message::ChatMessage;
+
+    #[test]
+    fn test_add_message_increases_new_message_count() {
+        let mut chat = Chat::default();
+        let message = ChatMessage::new_system("Test message");
+
+        chat.add_message(message);
+
+        assert_eq!(chat.new_message_count, 1);
+        assert_eq!(chat.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_add_message_does_not_increase_new_message_count_for_user() {
+        let mut chat = Chat::default();
+        let message = ChatMessage::new_user("Test message");
+
+        chat.add_message(message);
+
+        assert_eq!(chat.new_message_count, 0);
+        assert_eq!(chat.messages.len(), 1);
+    }
+
+    #[test]
+    fn test_add_message_tool_call() {
+        let mut chat = Chat::default();
+        let tool_call = chat_completion::ToolCall::builder()
+            .id("tool_call_id")
+            .name("some_tool")
+            .build()
+            .unwrap();
+        let message =
+            chat_completion::ChatMessage::new_tool_output(tool_call, String::new()).into();
+
+        chat.add_message(message);
+
+        assert!(chat.is_tool_call_completed("tool_call_id"));
+        assert_eq!(chat.messages.len(), 0);
+    }
+
+    #[test]
+    fn test_transition() {
+        let mut chat = Chat::default();
+        chat.transition(ChatState::Loading);
+
+        assert!(chat.is_loading());
+    }
+
+    #[test]
+    fn test_is_loading() {
+        let chat = Chat {
+            state: ChatState::Loading,
+            ..Default::default()
+        };
+
+        assert!(chat.is_loading());
+    }
+
+    #[test]
+    fn test_is_tool_call_completed() {
+        let mut chat = Chat::default();
+        chat.completed_tool_call_ids
+            .insert("tool_call_id".to_string());
+
+        assert!(chat.is_tool_call_completed("tool_call_id"));
+    }
+}

--- a/src/chat_message.rs
+++ b/src/chat_message.rs
@@ -98,7 +98,7 @@ impl ChatMessage {
     }
 
     #[must_use]
-    pub fn content(&self) -> &str {
+    pub fn formatted_content(&self) -> &str {
         &self.formatted_content
     }
     #[must_use]

--- a/src/chat_message.rs
+++ b/src/chat_message.rs
@@ -1,17 +1,14 @@
-use derive_builder::Builder;
-use uuid::Uuid;
-
 /// Represents a chat message that can be stored in a [`Chat`]
 ///
 /// Messages are expected to be formatted strings and are displayed as-is. Markdown is rendered
 /// using `tui-markdown`.
-#[derive(Clone, Default, Builder, PartialEq)]
-#[builder(setter(into, strip_option), build_fn(skip))]
+///
+/// TODO: All should be Cows
+#[derive(Clone, Default, PartialEq)]
 pub struct ChatMessage {
     role: ChatRole,
-    content: String,
+    formatted_content: String,
     original: Option<swiftide::chat_completion::ChatMessage>,
-    uuid: Option<Uuid>,
 }
 
 // Debug with truncated content
@@ -21,9 +18,9 @@ impl std::fmt::Debug for ChatMessage {
             .field("role", &self.role)
             .field(
                 "content",
-                &self.content[..std::cmp::min(10, self.content.len())].to_string(),
+                &self.formatted_content[..std::cmp::min(10, self.formatted_content.len())]
+                    .to_string(),
             )
-            .field("uuid", &self.uuid)
             .field("original", &self.original)
             .finish()
     }
@@ -50,60 +47,63 @@ pub enum ChatRole {
 }
 
 impl ChatMessage {
-    pub fn new_user(msg: impl Into<String>) -> ChatMessageBuilder {
-        ChatMessageBuilder::default()
-            .role(ChatRole::User)
-            .content(msg.into())
+    pub fn new_user(msg: impl Into<String>) -> ChatMessage {
+        ChatMessage::default()
+            .with_role(ChatRole::User)
+            .with_formatted_content(msg.into())
             .to_owned()
     }
 
-    pub fn new_system(msg: impl Into<String>) -> ChatMessageBuilder {
-        ChatMessageBuilder::default()
-            .role(ChatRole::System)
-            .content(msg.into())
+    pub fn new_system(msg: impl Into<String>) -> ChatMessage {
+        ChatMessage::default()
+            .with_role(ChatRole::System)
+            .with_formatted_content(msg.into())
             .to_owned()
     }
 
-    pub fn new_command(cmd: impl Into<String>) -> ChatMessageBuilder {
-        ChatMessageBuilder::default()
-            .role(ChatRole::Command)
-            .content(cmd.into().to_string())
+    pub fn new_command(cmd: impl Into<String>) -> ChatMessage {
+        ChatMessage::default()
+            .with_role(ChatRole::Command)
+            .with_formatted_content(cmd.into().to_string())
             .to_owned()
     }
 
-    pub fn new_assistant(msg: impl Into<String>) -> ChatMessageBuilder {
-        ChatMessageBuilder::default()
-            .role(ChatRole::Assistant)
-            .content(msg.into())
+    pub fn new_assistant(msg: impl Into<String>) -> ChatMessage {
+        ChatMessage::default()
+            .with_role(ChatRole::Assistant)
+            .with_formatted_content(msg.into())
             .to_owned()
     }
 
-    pub fn new_tool(msg: impl Into<String>) -> ChatMessageBuilder {
-        ChatMessageBuilder::default()
-            .role(ChatRole::Tool)
-            .content(msg.into())
+    pub fn new_tool(msg: impl Into<String>) -> ChatMessage {
+        ChatMessage::default()
+            .with_role(ChatRole::Tool)
+            .with_formatted_content(msg.into())
             .to_owned()
     }
 
-    #[must_use]
-    pub fn uuid(&self) -> Option<Uuid> {
-        self.uuid
+    pub fn with_role(&mut self, role: ChatRole) -> &mut Self {
+        self.role = role;
+        self
     }
+
+    pub fn with_formatted_content(&mut self, content: impl Into<String>) -> &mut Self {
+        self.formatted_content = content.into();
+        self
+    }
+
+    pub fn with_original(&mut self, original: swiftide::chat_completion::ChatMessage) -> &mut Self {
+        self.original = Some(original);
+        self
+    }
+
     #[must_use]
     pub fn content(&self) -> &str {
-        &self.content
+        &self.formatted_content
     }
     #[must_use]
     pub fn role(&self) -> &ChatRole {
         &self.role
-    }
-
-    #[must_use]
-    pub fn with_uuid(self, uuid: Uuid) -> Self {
-        Self {
-            uuid: Some(uuid),
-            ..self
-        }
     }
 
     #[must_use]
@@ -136,18 +136,6 @@ impl From<swiftide::chat_completion::ChatMessage> for ChatMessage {
             swiftide::chat_completion::ChatMessage::Summary(_) => unimplemented!(),
         };
 
-        builder.original(msg).build()
-    }
-}
-
-impl ChatMessageBuilder {
-    // Building is infallible
-    pub fn build(&mut self) -> ChatMessage {
-        ChatMessage {
-            content: self.content.clone().unwrap_or_default(),
-            uuid: self.uuid.unwrap_or_default(),
-            role: self.role.unwrap_or_default(),
-            original: self.original.clone().unwrap_or_default(),
-        }
+        builder.with_original(msg).to_owned()
     }
 }

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -47,22 +47,27 @@ pub struct CommandEvent {
 }
 
 impl CommandEvent {
+    #[must_use]
     pub fn builder() -> CommandEventBuilder {
         CommandEventBuilder::default()
     }
 
+    #[must_use]
     pub fn uuid(&self) -> Uuid {
         self.uuid
     }
 
+    #[must_use]
     pub fn command(&self) -> &Command {
         &self.command
     }
 
+    #[must_use]
     pub fn responder(&self) -> &dyn Responder {
         &self.responder
     }
 
+    #[must_use]
     pub fn clone_responder(&self) -> Arc<dyn Responder> {
         Arc::clone(&self.responder)
     }

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -5,9 +5,9 @@ use uuid::Uuid;
 /// By default all commands can be triggered from the ui like `/<command>`
 #[derive(
     Debug,
-    PartialEq,
-    Eq,
-    strum_macros::EnumString,
+    // PartialEq,
+    // Eq,
+    // strum_macros::EnumString,
     strum_macros::Display,
     strum_macros::IntoStaticStr,
     strum_macros::EnumIs,
@@ -15,11 +15,25 @@ use uuid::Uuid;
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum Command {
+    /// Cleanly stop the backend
     Quit { uuid: Uuid },
+
+    /// Print the config the backend is using
     ShowConfig { uuid: Uuid },
+    /// Re-index a repository
     IndexRepository { uuid: Uuid },
+
+    /// Stop an agent
     StopAgent { uuid: Uuid },
+
+    /// Chat with an agent
     Chat { uuid: Uuid, message: String },
+
+    /// Execute a tool executor compatible command in a running tool executor
+    Exec {
+        uuid: Uuid,
+        command: swiftide::traits::Command,
+    },
 }
 
 impl Command {
@@ -30,6 +44,7 @@ impl Command {
             | Command::StopAgent { uuid }
             | Command::ShowConfig { uuid }
             | Command::IndexRepository { uuid }
+            | Command::Exec { uuid, .. }
             | Command::Chat { uuid, .. } => *uuid,
         }
     }
@@ -41,6 +56,7 @@ impl Command {
             Command::Quit { .. } => Command::Quit { uuid },
             Command::ShowConfig { .. } => Command::ShowConfig { uuid },
             Command::IndexRepository { .. } => Command::IndexRepository { uuid },
+            Command::Exec { command, .. } => Command::Exec { uuid, command },
             Command::Chat { message, .. } => Command::Chat { uuid, message },
         }
     }

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -9,14 +9,7 @@ use super::Responder;
 ///
 /// By default all commands can be triggered from the ui like `/<command>`
 #[derive(
-    Debug,
-    // PartialEq,
-    // Eq,
-    // strum_macros::EnumString,
-    strum_macros::Display,
-    strum_macros::IntoStaticStr,
-    strum_macros::EnumIs,
-    Clone,
+    Debug, strum_macros::Display, strum_macros::IntoStaticStr, strum_macros::EnumIs, Clone,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum Command {
@@ -76,5 +69,51 @@ impl CommandEvent {
     pub fn with_uuid(mut self, uuid: Uuid) -> Self {
         self.uuid = uuid;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::MockResponder;
+
+    use super::*;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_command_event_builder() {
+        let command = Command::Quit;
+        let uuid = Uuid::new_v4();
+        let responder = Arc::new(MockResponder::new());
+
+        let event = CommandEvent::builder()
+            .command(command.clone())
+            .uuid(uuid)
+            .responder(responder.clone())
+            .build()
+            .unwrap();
+
+        let dyn_responder = responder as Arc<dyn Responder>;
+        assert!(event.command().is_quit());
+        assert_eq!(event.uuid(), uuid);
+        assert!(Arc::ptr_eq(&event.clone_responder(), &dyn_responder));
+    }
+
+    #[test]
+    fn test_with_uuid() {
+        let command = Command::ShowConfig;
+        let uuid = Uuid::new_v4();
+        let new_uuid = Uuid::new_v4();
+        let responder = Arc::new(MockResponder::new());
+
+        let event = CommandEvent::builder()
+            .command(command.clone())
+            .uuid(uuid)
+            .responder(responder.clone())
+            .build()
+            .unwrap()
+            .with_uuid(new_uuid);
+
+        assert_eq!(event.uuid(), new_uuid);
     }
 }

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -1,0 +1,47 @@
+use uuid::Uuid;
+
+/// Commands are the main way to interact with the backend
+///
+/// By default all commands can be triggered from the ui like `/<command>`
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    strum_macros::EnumString,
+    strum_macros::Display,
+    strum_macros::IntoStaticStr,
+    strum_macros::EnumIs,
+    Clone,
+)]
+#[strum(serialize_all = "snake_case")]
+pub enum Command {
+    Quit { uuid: Uuid },
+    ShowConfig { uuid: Uuid },
+    IndexRepository { uuid: Uuid },
+    StopAgent { uuid: Uuid },
+    Chat { uuid: Uuid, message: String },
+}
+
+impl Command {
+    #[must_use]
+    pub fn uuid(&self) -> Uuid {
+        match self {
+            Command::Quit { uuid }
+            | Command::StopAgent { uuid }
+            | Command::ShowConfig { uuid }
+            | Command::IndexRepository { uuid }
+            | Command::Chat { uuid, .. } => *uuid,
+        }
+    }
+
+    #[must_use]
+    pub fn with_uuid(self, uuid: Uuid) -> Self {
+        match self {
+            Command::StopAgent { .. } => Command::StopAgent { uuid },
+            Command::Quit { .. } => Command::Quit { uuid },
+            Command::ShowConfig { .. } => Command::ShowConfig { uuid },
+            Command::IndexRepository { .. } => Command::IndexRepository { uuid },
+            Command::Chat { message, .. } => Command::Chat { uuid, message },
+        }
+    }
+}

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -210,43 +210,4 @@ impl CommandHandler {
         responder.system_message("Agent stopped");
         Ok(())
     }
-
-    // Try to send a UI event, ignore if the UI is not connected
-    // fn send_ui_event(&self, event: impl Into<UIEvent>) {
-    //     let Some(ui_tx) = &self.ui_tx else { return };
-    //     let _ = ui_tx.send(event.into());
-    // }
-
-    // /// Forwards updates from the backend (i.e. agents) to the UI
-    // fn spawn_command_responder(&self, uuid: &Uuid) -> (CommandResponder, JoinHandle<()>) {
-    //     let mut command_responder = CommandResponder::default().with_uuid(*uuid);
-    //
-    //     let ui_tx_clone = self.ui_tx.clone().expect("expected ui tx");
-    //
-    //     // TODO: Perhaps nicer to have a single loop for all agents
-    //     // Then the majority of this can be moved to i.e. agents/running_agent
-    //     // Design wise: Agents should not know about UI, command handler and UI should not know
-    //     // about agent internals
-    //     // As long as nobody is running thousands of agents, this is fine
-    //     // TODO: Spawn should be impl on the command responder > putting ui tx behind an interface
-    //     // such that mapping of response to ui, can then be in the frontend.
-    //     let cloned_responder = command_responder.clone();
-    //     let handle = task::spawn(async move {
-    //         while let Some(response) = command_responder.recv().await {
-    //             match response {
-    //                 CommandResponse::Chat(msg) => {
-    //                     let _ = ui_tx_clone.send(msg.into());
-    //                 }
-    //                 CommandResponse::ActivityUpdate(uuid, state) => {
-    //                     let _ = ui_tx_clone.send(UIEvent::ActivityUpdate(uuid, state));
-    //                 }
-    //                 CommandResponse::RenameChat(uuid, name) => {
-    //                     let _ = ui_tx_clone.send(UIEvent::RenameChat(uuid, name));
-    //                 }
-    //             }
-    //         }
-    //     });
-    //
-    //     (cloned_responder, handle)
-    // }
 }

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -3,12 +3,12 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 use anyhow::Result;
 use tokio::{
     sync::{mpsc, Mutex, RwLock},
-    task::{self, JoinHandle},
+    task::{self},
 };
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::{agent, chat_message::ChatMessage, frontend::App, indexing, repository::Repository};
+use crate::{agent, frontend::App, indexing, repository::Repository};
 
 use super::{
     command::{Command, CommandEvent},
@@ -112,7 +112,7 @@ impl CommandHandler {
         match cmd {
             Command::StopAgent => {
                 self.stop_agent(event.uuid(), event.clone_responder())
-                    .await?
+                    .await?;
             }
             Command::IndexRepository { .. } => {
                 indexing::index_repository(repository, Some(event.clone_responder())).await?;

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -8,33 +8,23 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::{
-    agent,
-    chat_message::ChatMessage,
-    frontend::{App, UIEvent},
-    indexing,
-    repository::Repository,
-};
+use crate::{agent, chat_message::ChatMessage, frontend::App, indexing, repository::Repository};
 
 use super::{
-    command::Command,
-    responder::{CommandResponder, CommandResponse},
+    command::{Command, CommandEvent},
+    responder::{CommandResponse, Responder},
     running_agent::RunningAgent,
 };
 
 /// Commands always flow via the `CommandHandler`
+///
+/// It is the principle entry point for the backend, and handles all commands
 pub struct CommandHandler {
     /// Receives commands
-    rx: Option<mpsc::UnboundedReceiver<Command>>,
+    rx: Option<mpsc::UnboundedReceiver<CommandEvent>>,
     /// Sends commands
-    tx: mpsc::UnboundedSender<Command>,
+    tx: mpsc::UnboundedSender<CommandEvent>,
 
-    /// TODO: Remove this and use the command responder everywhere
-    /// Then there can also be a single command responder, and removes coupling with frontend
-    /// fully
-    ///
-    /// Sends `UIEvents` to the connected frontend
-    ui_tx: Option<mpsc::UnboundedSender<UIEvent>>,
     /// Repository to interact with
     repository: Arc<Repository>,
 
@@ -49,14 +39,12 @@ impl CommandHandler {
         CommandHandler {
             rx: Some(rx),
             tx,
-            ui_tx: None,
             repository: Arc::new(repository.into()),
             agents: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
     pub fn register_ui(&mut self, app: &mut App) {
-        self.ui_tx = Some(app.ui_tx.clone());
         app.command_tx = Some(self.tx.clone());
     }
 
@@ -69,7 +57,6 @@ impl CommandHandler {
     /// - Missing receiver for commands
     pub fn start(mut self) -> tokio::task::JoinHandle<()> {
         let repository = Arc::clone(&self.repository);
-        let ui_tx = self.ui_tx.clone().expect("Expected a registered ui");
         let mut rx = self.rx.take().expect("Expected a receiver");
         let this_handler = Arc::new(self);
 
@@ -78,9 +65,9 @@ impl CommandHandler {
             // JoinSet invokes abort on drop
             let mut joinset = tokio::task::JoinSet::new();
 
-            while let Some(cmd) = rx.recv().await {
+            while let Some(event) = rx.recv().await {
                 // On `Quit`, abort all running tasks, wait for them to finish then break.
-                if cmd.is_quit() {
+                if event.command().is_quit() {
                     tracing::warn!("Backend received quit command, shutting down");
                     joinset.shutdown().await;
                     tracing::warn!("Backend shutdown complete");
@@ -89,25 +76,18 @@ impl CommandHandler {
                 }
 
                 let repository = Arc::clone(&repository);
-                let ui_tx = ui_tx.clone();
                 let this_handler = Arc::clone(&this_handler);
 
                 joinset.spawn(async move {
-                    let result = this_handler.handle_command(&repository,  &cmd).await;
-                    ui_tx.send(UIEvent::CommandDone(cmd.uuid())).unwrap();
+                    let result = this_handler.handle_command_event(&repository, &event, &event.command()).await;
+                    // ui_tx.send(UIEvent::CommandDone(cmd.uuid())).unwrap();
+                    event.responder().handle(CommandResponse::Completed(event.uuid()));
 
                     if let Err(error) = result {
-                        tracing::error!(?error, %cmd, "Failed to handle command {cmd} with error {error:#}");
-                        ui_tx
-                            .send(
-                                ChatMessage::new_system(format!(
+                        tracing::error!(?error, cmd = %event.command(), "Failed to handle command {cmd} with error {error:#}", cmd= event.command());
+                            event.responder().system_message(&format!(
                                     "Failed to handle command: {error:#}"
-                                ))
-                                .uuid(cmd.uuid())
-                                .to_owned()
-                                .into(),
-                            )
-                            .unwrap();
+                                ));
                     };
                 });
             }
@@ -118,28 +98,33 @@ impl CommandHandler {
 
     /// TODO: Most commands should probably be handled in a tokio task
     /// Maybe generalize tasks to make ui updates easier?
-    #[tracing::instrument(skip_all, fields(otel.name = %cmd.to_string(), uuid = %cmd.uuid()), err)]
-    async fn handle_command(&self, repository: &Repository, cmd: &Command) -> Result<()> {
+    #[tracing::instrument(skip_all, fields(otel.name = %cmd.to_string(), uuid = %event.uuid()), err)]
+    async fn handle_command_event(
+        &self,
+        repository: &Repository,
+        event: &CommandEvent,
+        cmd: &Command,
+    ) -> Result<()> {
         let now = std::time::Instant::now();
         tracing::warn!("Handling command {cmd}");
 
         #[allow(clippy::match_wildcard_for_single_variants)]
         match cmd {
-            Command::StopAgent { uuid } => self.stop_agent(*uuid).await?,
+            Command::StopAgent => {
+                self.stop_agent(event.uuid(), event.clone_responder())
+                    .await?
+            }
             Command::IndexRepository { .. } => {
-                let (command_responder, _guard) = self.spawn_command_responder(&cmd.uuid());
-                indexing::index_repository(repository, Some(command_responder)).await?;
+                indexing::index_repository(repository, Some(event.clone_responder())).await?;
             }
-            Command::ShowConfig { uuid } => {
-                self.send_ui_event(
-                    ChatMessage::new_system(toml::to_string_pretty(repository.config())?)
-                        .uuid(*uuid)
-                        .to_owned(),
-                );
-            }
-            Command::Chat { uuid, ref message } => {
+            Command::ShowConfig => event
+                .responder()
+                .system_message(&toml::to_string_pretty(repository.config())?),
+            Command::Chat { ref message } => {
                 let message = message.clone();
-                let agent = self.find_or_start_agent_by_uuid(*uuid, &message).await?;
+                let agent = self
+                    .find_or_start_agent_by_uuid(event.uuid(), &message, event.clone_responder())
+                    .await?;
                 let token = agent.cancel_token.clone();
 
                 tokio::select! {
@@ -148,16 +133,16 @@ impl CommandHandler {
 
                 }?;
             }
-            Command::Exec { uuid, command } => {
-                let Some(agent) = self.find_agent_by_uuid(*uuid).await else {
-                    self.send_ui_event(
-                        ChatMessage::new_system("No agent found (yet), is it starting up?")
-                            .uuid(*uuid),
-                    );
+            Command::Exec { command } => {
+                let Some(agent) = self.find_agent_by_uuid(event.uuid()).await else {
+                    event
+                        .responder()
+                        .system_message("No agent found (yet), is it starting up?");
                     return Ok(());
                 };
 
                 let result = agent.executor.exec_cmd(&command).await;
+                todo!();
 
                 // And now it needs to go back to the frontend again
             }
@@ -166,32 +151,31 @@ impl CommandHandler {
         // Sleep for a tiny bit to avoid racing with agent responses
         tokio::time::sleep(Duration::from_millis(50)).await;
         let elapsed = now.elapsed();
-        self.send_ui_event(
-            ChatMessage::new_system(format!(
-                "Command {cmd} successful in {} seconds",
-                elapsed.as_secs_f64().round()
-            ))
-            .uuid(cmd.uuid()),
-        );
+        event.responder().system_message(&format!(
+            "Command {cmd} successful in {} seconds",
+            elapsed.as_secs_f64().round()
+        ));
 
         Ok(())
     }
 
-    async fn find_or_start_agent_by_uuid(&self, uuid: Uuid, query: &str) -> Result<RunningAgent> {
+    async fn find_or_start_agent_by_uuid(
+        &self,
+        uuid: Uuid,
+        query: &str,
+        responder: Arc<dyn Responder>,
+    ) -> Result<RunningAgent> {
         if let Some(agent) = self.agents.write().await.get_mut(&uuid) {
             // Ensure we always send a fresh cancellation token
             agent.cancel_token = CancellationToken::new();
             return Ok(agent.clone());
         }
 
-        let (responder, handle) = self.spawn_command_responder(&uuid);
-
         let (agent, executor) =
             agent::build_agent(uuid, &self.repository, query, responder).await?;
 
         let running_agent = RunningAgent {
             agent: Arc::new(Mutex::new(agent)),
-            response_handle: Arc::new(handle),
             cancel_token: CancellationToken::new(),
             executor,
         };
@@ -207,17 +191,15 @@ impl CommandHandler {
         agents.get(&uuid).cloned()
     }
 
-    async fn stop_agent(&self, uuid: Uuid) -> Result<()> {
+    async fn stop_agent(&self, uuid: Uuid, responder: Arc<dyn Responder>) -> Result<()> {
         let mut locked_agents = self.agents.write().await;
         let Some(agent) = locked_agents.get_mut(&uuid) else {
-            self.send_ui_event(
-                ChatMessage::new_system("No agent found (yet), is it starting up?").uuid(uuid),
-            );
+            responder.system_message("No agent found (yet), is it starting up?");
             return Ok(());
         };
 
         if agent.cancel_token.is_cancelled() {
-            self.send_ui_event(ChatMessage::new_system("Agent already stopped").uuid(uuid));
+            responder.system_message("Agent already stopped");
             return Ok(());
         }
 
@@ -225,46 +207,46 @@ impl CommandHandler {
         // Perhaps something to re-align it?
         agent.stop().await;
 
-        self.send_ui_event(ChatMessage::new_system("Agent stopped").uuid(uuid));
+        responder.system_message("Agent stopped");
         Ok(())
     }
 
     // Try to send a UI event, ignore if the UI is not connected
-    fn send_ui_event(&self, event: impl Into<UIEvent>) {
-        let Some(ui_tx) = &self.ui_tx else { return };
-        let _ = ui_tx.send(event.into());
-    }
+    // fn send_ui_event(&self, event: impl Into<UIEvent>) {
+    //     let Some(ui_tx) = &self.ui_tx else { return };
+    //     let _ = ui_tx.send(event.into());
+    // }
 
-    /// Forwards updates from the backend (i.e. agents) to the UI
-    fn spawn_command_responder(&self, uuid: &Uuid) -> (CommandResponder, JoinHandle<()>) {
-        let mut command_responder = CommandResponder::default().with_uuid(*uuid);
-
-        let ui_tx_clone = self.ui_tx.clone().expect("expected ui tx");
-
-        // TODO: Perhaps nicer to have a single loop for all agents
-        // Then the majority of this can be moved to i.e. agents/running_agent
-        // Design wise: Agents should not know about UI, command handler and UI should not know
-        // about agent internals
-        // As long as nobody is running thousands of agents, this is fine
-        // TODO: Spawn should be impl on the command responder > putting ui tx behind an interface
-        // such that mapping of response to ui, can then be in the frontend.
-        let cloned_responder = command_responder.clone();
-        let handle = task::spawn(async move {
-            while let Some(response) = command_responder.recv().await {
-                match response {
-                    CommandResponse::Chat(msg) => {
-                        let _ = ui_tx_clone.send(msg.into());
-                    }
-                    CommandResponse::ActivityUpdate(uuid, state) => {
-                        let _ = ui_tx_clone.send(UIEvent::ActivityUpdate(uuid, state));
-                    }
-                    CommandResponse::RenameChat(uuid, name) => {
-                        let _ = ui_tx_clone.send(UIEvent::RenameChat(uuid, name));
-                    }
-                }
-            }
-        });
-
-        (cloned_responder, handle)
-    }
+    // /// Forwards updates from the backend (i.e. agents) to the UI
+    // fn spawn_command_responder(&self, uuid: &Uuid) -> (CommandResponder, JoinHandle<()>) {
+    //     let mut command_responder = CommandResponder::default().with_uuid(*uuid);
+    //
+    //     let ui_tx_clone = self.ui_tx.clone().expect("expected ui tx");
+    //
+    //     // TODO: Perhaps nicer to have a single loop for all agents
+    //     // Then the majority of this can be moved to i.e. agents/running_agent
+    //     // Design wise: Agents should not know about UI, command handler and UI should not know
+    //     // about agent internals
+    //     // As long as nobody is running thousands of agents, this is fine
+    //     // TODO: Spawn should be impl on the command responder > putting ui tx behind an interface
+    //     // such that mapping of response to ui, can then be in the frontend.
+    //     let cloned_responder = command_responder.clone();
+    //     let handle = task::spawn(async move {
+    //         while let Some(response) = command_responder.recv().await {
+    //             match response {
+    //                 CommandResponse::Chat(msg) => {
+    //                     let _ = ui_tx_clone.send(msg.into());
+    //                 }
+    //                 CommandResponse::ActivityUpdate(uuid, state) => {
+    //                     let _ = ui_tx_clone.send(UIEvent::ActivityUpdate(uuid, state));
+    //                 }
+    //                 CommandResponse::RenameChat(uuid, name) => {
+    //                     let _ = ui_tx_clone.send(UIEvent::RenameChat(uuid, name));
+    //                 }
+    //             }
+    //         }
+    //     });
+    //
+    //     (cloned_responder, handle)
+    // }
 }

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Result;
-use swiftide::agents::Agent;
 use tokio::{
     sync::{mpsc, Mutex, RwLock},
     task::{self, JoinHandle},
@@ -17,139 +16,11 @@ use crate::{
     repository::Repository,
 };
 
-/// Commands represent concrete actions from a user or in the backend
-///
-/// By default all commands can be triggered from the ui like `/<command>`
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    strum_macros::EnumString,
-    strum_macros::Display,
-    strum_macros::IntoStaticStr,
-    strum_macros::EnumIs,
-    Clone,
-)]
-#[strum(serialize_all = "snake_case")]
-pub enum Command {
-    Quit { uuid: Uuid },
-    ShowConfig { uuid: Uuid },
-    IndexRepository { uuid: Uuid },
-    StopAgent { uuid: Uuid },
-    Chat { uuid: Uuid, message: String },
-}
-
-#[derive(Debug, Clone)]
-pub enum CommandResponse {
-    Chat(ChatMessage),
-    ActivityUpdate(Uuid, String),
-    RenameChat(Uuid, String),
-}
-
-#[derive(Debug)]
-pub struct CommandResponder {
-    tx: mpsc::UnboundedSender<CommandResponse>,
-    rx: Option<mpsc::UnboundedReceiver<CommandResponse>>,
-    uuid: Uuid,
-}
-
-impl CommandResponder {
-    #[allow(dead_code)]
-    pub fn send_system_message(&self, message: impl Into<String>) {
-        self.send_message(ChatMessage::new_system(message).build());
-    }
-
-    pub fn send_message(&self, msg: impl Into<ChatMessage>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::Chat(msg.into().with_uuid(self.uuid)));
-    }
-
-    pub fn send_update(&self, state: impl Into<String>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::ActivityUpdate(self.uuid, state.into()));
-    }
-
-    // TODO: this feels overly specific, but its a real thing
-    pub fn send_rename(&self, name: impl Into<String>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::RenameChat(self.uuid, name.into()));
-    }
-
-    #[must_use]
-    /// Start receiving command responses
-    ///
-    /// # Panics
-    ///
-    /// Panics if the recev is already taken
-    pub async fn recv(&mut self) -> Option<CommandResponse> {
-        let rx = self.rx.as_mut().expect("Expected a receiver");
-        rx.recv().await
-    }
-
-    #[must_use]
-    pub fn with_uuid(self, uuid: Uuid) -> Self {
-        CommandResponder {
-            tx: self.tx,
-            rx: self.rx,
-            uuid,
-        }
-    }
-}
-
-impl Default for CommandResponder {
-    fn default() -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
-        CommandResponder {
-            tx,
-            rx: Some(rx),
-            uuid: Uuid::default(),
-        }
-    }
-}
-
-/// Cheap clone that uninitializes the receiver
-impl Clone for CommandResponder {
-    fn clone(&self) -> Self {
-        CommandResponder {
-            tx: self.tx.clone(),
-            rx: None,
-            uuid: self.uuid,
-        }
-    }
-}
-
-impl From<ChatMessage> for CommandResponse {
-    fn from(msg: ChatMessage) -> Self {
-        CommandResponse::Chat(msg)
-    }
-}
-
-impl Command {
-    #[must_use]
-    pub fn uuid(&self) -> Uuid {
-        match self {
-            Command::Quit { uuid }
-            | Command::StopAgent { uuid }
-            | Command::ShowConfig { uuid }
-            | Command::IndexRepository { uuid }
-            | Command::Chat { uuid, .. } => *uuid,
-        }
-    }
-
-    #[must_use]
-    pub fn with_uuid(self, uuid: Uuid) -> Self {
-        match self {
-            Command::StopAgent { .. } => Command::StopAgent { uuid },
-            Command::Quit { .. } => Command::Quit { uuid },
-            Command::ShowConfig { .. } => Command::ShowConfig { uuid },
-            Command::IndexRepository { .. } => Command::IndexRepository { uuid },
-            Command::Chat { message, .. } => Command::Chat { uuid, message },
-        }
-    }
-}
+use super::{
+    command::Command,
+    responder::{CommandResponder, CommandResponse},
+    running_agent::RunningAgent,
+};
 
 /// Commands always flow via the `CommandHandler`
 pub struct CommandHandler {
@@ -169,27 +40,6 @@ pub struct CommandHandler {
 
     /// TODO: Fix this, too tired to think straight
     agents: Arc<RwLock<HashMap<Uuid, RunningAgent>>>,
-}
-
-#[derive(Clone)]
-struct RunningAgent {
-    agent: Arc<Mutex<Agent>>,
-
-    #[allow(dead_code)]
-    response_handle: Arc<tokio::task::JoinHandle<()>>,
-
-    cancel_token: CancellationToken,
-}
-
-impl RunningAgent {
-    pub async fn query(&self, query: &str) -> Result<()> {
-        self.agent.lock().await.query(query).await
-    }
-
-    pub async fn stop(&self) {
-        self.cancel_token.cancel();
-        self.agent.lock().await.stop();
-    }
 }
 
 impl CommandHandler {
@@ -376,6 +226,8 @@ impl CommandHandler {
         // Design wise: Agents should not know about UI, command handler and UI should not know
         // about agent internals
         // As long as nobody is running thousands of agents, this is fine
+        // TODO: Spawn should be impl on the command responder > putting ui tx behind an interface
+        // such that mapping of response to ui, can then be in the frontend.
         let cloned_responder = command_responder.clone();
         let handle = task::spawn(async move {
             while let Some(response) = command_responder.recv().await {

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -141,7 +141,7 @@ impl CommandHandler {
                     return Ok(());
                 };
 
-                let result = agent.executor.exec_cmd(&command).await;
+                let _result = agent.executor.exec_cmd(&command).await;
                 todo!();
 
                 // And now it needs to go back to the frontend again

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,0 +1,9 @@
+//! Kwaak uses a command pattern to handle the backend asynchroniously.
+mod command;
+mod handler;
+mod responder;
+mod running_agent;
+
+pub use command::Command;
+pub use handler::CommandHandler;
+pub use responder::{CommandResponder, CommandResponse};

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,9 @@ mod handler;
 mod responder;
 mod running_agent;
 
-pub use command::Command;
+pub use command::{Command, CommandEvent};
 pub use handler::CommandHandler;
-pub use responder::{CommandResponder, CommandResponse};
+pub use responder::{CommandResponse, Responder};
+
+#[cfg(test)]
+pub use responder::MockResponder;

--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -1,92 +1,112 @@
+use std::sync::Arc;
+
+#[cfg(test)]
+use mockall::{automock, mock};
+use swiftide::chat_completion;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::chat_message::ChatMessage;
 
+/// Uuid here refers to the identifer of the command
+///
+/// TODO: Remove the UUID here, the responder is expected to know the uuid
+/// of the command, and it confuses with the uuid to identify chats (same value only for convience,
+/// not the same 'thing')
 #[derive(Debug, Clone)]
 pub enum CommandResponse {
-    Chat(ChatMessage),
+    Chat(Uuid, chat_completion::ChatMessage),
     ActivityUpdate(Uuid, String),
     RenameChat(Uuid, String),
+    Completed(Uuid),
 }
 
-#[derive(Debug)]
-pub struct CommandResponder {
-    tx: mpsc::UnboundedSender<CommandResponse>,
-    rx: Option<mpsc::UnboundedReceiver<CommandResponse>>,
-    uuid: Uuid,
-}
-
-impl CommandResponder {
-    #[allow(dead_code)]
-    pub fn send_system_message(&self, message: impl Into<String>) {
-        self.send_message(ChatMessage::new_system(message).build());
-    }
-
-    pub fn send_message(&self, msg: impl Into<ChatMessage>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::Chat(msg.into().with_uuid(self.uuid)));
-    }
-
-    pub fn send_update(&self, state: impl Into<String>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::ActivityUpdate(self.uuid, state.into()));
-    }
-
-    // TODO: this feels overly specific, but its a real thing
-    pub fn send_rename(&self, name: impl Into<String>) {
-        let _ = self
-            .tx
-            .send(CommandResponse::RenameChat(self.uuid, name.into()));
-    }
-
-    #[must_use]
-    /// Start receiving command responses
-    ///
-    /// # Panics
-    ///
-    /// Panics if the recev is already taken
-    pub async fn recv(&mut self) -> Option<CommandResponse> {
-        let rx = self.rx.as_mut().expect("Expected a receiver");
-        rx.recv().await
-    }
-
-    #[must_use]
+impl CommandResponse {
     pub fn with_uuid(self, uuid: Uuid) -> Self {
-        CommandResponder {
-            tx: self.tx,
-            rx: self.rx,
-            uuid,
+        match self {
+            CommandResponse::Chat(uuid, msg) => CommandResponse::Chat(uuid, msg),
+            CommandResponse::ActivityUpdate(_, state) => {
+                CommandResponse::ActivityUpdate(uuid, state)
+            }
+            CommandResponse::RenameChat(_, name) => CommandResponse::RenameChat(uuid, name),
+            CommandResponse::Completed(_) => CommandResponse::Completed(uuid),
         }
     }
 }
 
-impl Default for CommandResponder {
-    fn default() -> Self {
-        let (tx, rx) = mpsc::unbounded_channel();
-        CommandResponder {
-            tx,
-            rx: Some(rx),
-            uuid: Uuid::default(),
-        }
+/// A responder reacts to updates from commands
+///
+/// Backend defines the interface, frontend can define ways to handle the responses
+///
+/// TODO: Consider, perhaps with the new structure, less concrete methods are needed
+/// and the frontend just uses a oneoff handler for each command
+#[cfg_attr(test, automock)]
+pub trait Responder: std::fmt::Debug + Send + Sync {
+    /// Generic handler for command responses
+    fn handle(&self, response: CommandResponse);
+
+    /// Messages from an agent
+    fn agent_message(&self, message: chat_completion::ChatMessage);
+
+    /// System messages from the backend
+    fn system_message(&self, message: &str);
+
+    /// State updates with a message from the backend
+    fn update(&self, state: &str);
+
+    /// Response to a rename request
+    fn rename(&self, name: &str);
+}
+
+impl Responder for tokio::sync::mpsc::UnboundedSender<CommandResponse> {
+    fn handle(&self, response: CommandResponse) {
+        let _ = self.send(response);
+    }
+
+    fn agent_message(&self, message: chat_completion::ChatMessage) {
+        let _ = self.send(CommandResponse::Chat(Uuid::default(), message));
+    }
+
+    fn system_message(&self, message: &str) {
+        let _ = self.send(CommandResponse::ActivityUpdate(
+            Uuid::default(),
+            message.to_string(),
+        ));
+    }
+
+    fn update(&self, state: &str) {
+        let _ = self.send(CommandResponse::ActivityUpdate(
+            Uuid::default(),
+            state.to_string(),
+        ));
+    }
+
+    fn rename(&self, name: &str) {
+        let _ = self.send(CommandResponse::RenameChat(
+            Uuid::default(),
+            name.to_string(),
+        ));
     }
 }
 
-/// Cheap clone that uninitializes the receiver
-impl Clone for CommandResponder {
-    fn clone(&self) -> Self {
-        CommandResponder {
-            tx: self.tx.clone(),
-            rx: None,
-            uuid: self.uuid,
-        }
+impl Responder for Arc<dyn Responder> {
+    fn handle(&self, response: CommandResponse) {
+        self.as_ref().handle(response);
     }
-}
 
-impl From<ChatMessage> for CommandResponse {
-    fn from(msg: ChatMessage) -> Self {
-        CommandResponse::Chat(msg)
+    fn agent_message(&self, message: chat_completion::ChatMessage) {
+        self.as_ref().agent_message(message);
+    }
+
+    fn system_message(&self, message: &str) {
+        self.as_ref().system_message(message);
+    }
+
+    fn update(&self, state: &str) {
+        self.as_ref().update(state);
+    }
+
+    fn rename(&self, name: &str) {
+        self.as_ref().rename(name);
     }
 }

--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 /// Uuid here refers to the identifier of the command
 ///
 /// TODO: Remove the UUID here, the responder is expected to know the uuid
-/// of the command, and it confuses with the uuid to identify chats (same value only for convience,
+/// of the command, and it confuses with the uuid to identify chats (same value only for convenience,
 /// not the same 'thing')
 #[derive(Debug, Clone)]
 pub enum CommandResponse {

--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -1,14 +1,11 @@
 use std::sync::Arc;
 
 #[cfg(test)]
-use mockall::{automock, mock};
+use mockall::automock;
 use swiftide::chat_completion;
-use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::chat_message::ChatMessage;
-
-/// Uuid here refers to the identifer of the command
+/// Uuid here refers to the identifier of the command
 ///
 /// TODO: Remove the UUID here, the responder is expected to know the uuid
 /// of the command, and it confuses with the uuid to identify chats (same value only for convience,
@@ -22,6 +19,7 @@ pub enum CommandResponse {
 }
 
 impl CommandResponse {
+    #[must_use]
     pub fn with_uuid(self, uuid: Uuid) -> Self {
         match self {
             CommandResponse::Chat(uuid, msg) => CommandResponse::Chat(uuid, msg),

--- a/src/commands/responder.rs
+++ b/src/commands/responder.rs
@@ -1,0 +1,92 @@
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::chat_message::ChatMessage;
+
+#[derive(Debug, Clone)]
+pub enum CommandResponse {
+    Chat(ChatMessage),
+    ActivityUpdate(Uuid, String),
+    RenameChat(Uuid, String),
+}
+
+#[derive(Debug)]
+pub struct CommandResponder {
+    tx: mpsc::UnboundedSender<CommandResponse>,
+    rx: Option<mpsc::UnboundedReceiver<CommandResponse>>,
+    uuid: Uuid,
+}
+
+impl CommandResponder {
+    #[allow(dead_code)]
+    pub fn send_system_message(&self, message: impl Into<String>) {
+        self.send_message(ChatMessage::new_system(message).build());
+    }
+
+    pub fn send_message(&self, msg: impl Into<ChatMessage>) {
+        let _ = self
+            .tx
+            .send(CommandResponse::Chat(msg.into().with_uuid(self.uuid)));
+    }
+
+    pub fn send_update(&self, state: impl Into<String>) {
+        let _ = self
+            .tx
+            .send(CommandResponse::ActivityUpdate(self.uuid, state.into()));
+    }
+
+    // TODO: this feels overly specific, but its a real thing
+    pub fn send_rename(&self, name: impl Into<String>) {
+        let _ = self
+            .tx
+            .send(CommandResponse::RenameChat(self.uuid, name.into()));
+    }
+
+    #[must_use]
+    /// Start receiving command responses
+    ///
+    /// # Panics
+    ///
+    /// Panics if the recev is already taken
+    pub async fn recv(&mut self) -> Option<CommandResponse> {
+        let rx = self.rx.as_mut().expect("Expected a receiver");
+        rx.recv().await
+    }
+
+    #[must_use]
+    pub fn with_uuid(self, uuid: Uuid) -> Self {
+        CommandResponder {
+            tx: self.tx,
+            rx: self.rx,
+            uuid,
+        }
+    }
+}
+
+impl Default for CommandResponder {
+    fn default() -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        CommandResponder {
+            tx,
+            rx: Some(rx),
+            uuid: Uuid::default(),
+        }
+    }
+}
+
+/// Cheap clone that uninitializes the receiver
+impl Clone for CommandResponder {
+    fn clone(&self) -> Self {
+        CommandResponder {
+            tx: self.tx.clone(),
+            rx: None,
+            uuid: self.uuid,
+        }
+    }
+}
+
+impl From<ChatMessage> for CommandResponse {
+    fn from(msg: ChatMessage) -> Self {
+        CommandResponse::Chat(msg)
+    }
+}

--- a/src/commands/running_agent.rs
+++ b/src/commands/running_agent.rs
@@ -8,13 +8,11 @@ use tokio_util::sync::CancellationToken;
 
 #[derive(Clone)]
 pub struct RunningAgent {
+    /// The agent that is running
     pub agent: Arc<Mutex<Agent>>,
-
+    /// A copy of the running tool executor the agent is using
     pub executor: Arc<dyn ToolExecutor>,
-
-    #[allow(dead_code)]
-    pub response_handle: Arc<tokio::task::JoinHandle<()>>,
-
+    /// Used to kill the agent
     pub cancel_token: CancellationToken,
 }
 

--- a/src/commands/running_agent.rs
+++ b/src/commands/running_agent.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+use std::sync::Arc;
+
+use swiftide::agents::Agent;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct RunningAgent {
+    pub agent: Arc<Mutex<Agent>>,
+
+    #[allow(dead_code)]
+    pub response_handle: Arc<tokio::task::JoinHandle<()>>,
+
+    pub cancel_token: CancellationToken,
+}
+
+impl RunningAgent {
+    pub async fn query(&self, query: &str) -> Result<()> {
+        self.agent.lock().await.query(query).await
+    }
+
+    pub async fn stop(&self) {
+        self.cancel_token.cancel();
+        self.agent.lock().await.stop();
+    }
+}

--- a/src/commands/running_agent.rs
+++ b/src/commands/running_agent.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::sync::Arc;
+use swiftide_core::ToolExecutor;
 
 use swiftide::agents::Agent;
 use tokio::sync::Mutex;
@@ -8,6 +9,8 @@ use tokio_util::sync::CancellationToken;
 #[derive(Clone)]
 pub struct RunningAgent {
     pub agent: Arc<Mutex<Agent>>,
+
+    pub executor: Arc<dyn ToolExecutor>,
 
     #[allow(dead_code)]
     pub response_handle: Arc<tokio::task::JoinHandle<()>>,

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -342,7 +342,7 @@ impl App<'_> {
                                     .filter(|m| m.role().is_assistant() || m.role().is_user())
                                     .last()
                             })
-                            .map(ChatMessage::content)
+                            .map(ChatMessage::formatted_content)
                         else {
                             self.add_chat_message(
                                 self.current_chat_uuid,

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -365,8 +365,8 @@ impl App<'_> {
                     UIEvent::UserInputCommand(uuid, cmd) => {
                         if let Some(cmd) = cmd.to_command() {
                             self.dispatch_command(uuid, cmd);
-                        } else if let Ok(cmd) = UIEvent::try_from(cmd.clone()) {
-                            self.send_ui_event(cmd);
+                        } else if let Some(event) = cmd.to_ui_event() {
+                            self.send_ui_event(event);
                         } else {
                             tracing::error!("Could not convert ui command to backend command nor ui event {cmd}");
                             self.add_chat_message(

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -216,7 +216,7 @@ impl App<'_> {
             .expect("Failed to dispatch command");
     }
 
-    fn add_chat_message(&mut self, chat_id: Uuid, message: impl Into<ChatMessage>) {
+    pub fn add_chat_message(&mut self, chat_id: Uuid, message: impl Into<ChatMessage>) {
         let message = message.into();
         if chat_id == self.boot_uuid {
             return;
@@ -386,19 +386,19 @@ impl App<'_> {
         Ok(())
     }
 
-    fn find_chat_mut(&mut self, uuid: Uuid) -> Option<&mut Chat> {
+    pub fn find_chat_mut(&mut self, uuid: Uuid) -> Option<&mut Chat> {
         self.chats.iter_mut().find(|chat| chat.uuid == uuid)
     }
 
-    fn find_chat(&self, uuid: Uuid) -> Option<&Chat> {
+    pub fn find_chat(&self, uuid: Uuid) -> Option<&Chat> {
         self.chats.iter().find(|chat| chat.uuid == uuid)
     }
 
-    pub(crate) fn current_chat(&self) -> Option<&Chat> {
+    pub fn current_chat(&self) -> Option<&Chat> {
         self.find_chat(self.current_chat_uuid)
     }
 
-    pub(crate) fn current_chat_mut(&mut self) -> Option<&mut Chat> {
+    pub fn current_chat_mut(&mut self) -> Option<&mut Chat> {
         self.find_chat_mut(self.current_chat_uuid)
     }
 
@@ -410,7 +410,7 @@ impl App<'_> {
         self.chats_state.select_last();
     }
 
-    fn next_chat(&mut self) {
+    pub fn next_chat(&mut self) {
         #[allow(clippy::skip_while_next)]
         let Some(next_idx) = self
             .chats

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -418,8 +418,17 @@ impl App<'_> {
             .position(|chat| chat.uuid == self.current_chat_uuid)
             .map(|idx| idx + 1)
         else {
+            debug_assert!(
+                false,
+                "No chats in app found when selecting next app, this should never happen"
+            );
             let Some(chat) = self.chats.first() else {
-                panic!("No chats in app found when selecting next app, this should never happen")
+                tracing::error!(
+                    "No chats in app found when selecting next app, this should never happen"
+                );
+
+                self.add_chat(Chat::default());
+                return;
             };
 
             let uuid = chat.uuid;

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use copypasta::{ClipboardContext, ClipboardProvider};
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use strum::IntoEnumIterator as _;
 use tui_logger::TuiWidgetState;
 use tui_textarea::TextArea;
@@ -19,7 +19,7 @@ use tokio::task;
 use crate::{
     chat::{Chat, ChatState},
     chat_message::ChatMessage,
-    commands::{Command, CommandEvent, Responder},
+    commands::{Command, CommandEvent},
     frontend,
 };
 

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -418,11 +418,11 @@ impl App<'_> {
             .position(|chat| chat.uuid == self.current_chat_uuid)
             .map(|idx| idx + 1)
         else {
-            debug_assert!(
-                false,
-                "No chats in app found when selecting next app, this should never happen"
-            );
             let Some(chat) = self.chats.first() else {
+                debug_assert!(
+                    false,
+                    "No chats in app found when selecting next app, this should never happen"
+                );
                 tracing::error!(
                     "No chats in app found when selecting next app, this should never happen"
                 );

--- a/src/frontend/app_command_responder.rs
+++ b/src/frontend/app_command_responder.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, OnceLock};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use swiftide::chat_completion;
 use tokio::sync::mpsc;
 use uuid::Uuid;
@@ -14,7 +14,7 @@ static INSTANCE: OnceLock<Arc<AppCommandResponder>> = OnceLock::new();
 /// Handles responses from commands application wide
 ///
 /// Basically converts command responses into UI events
-/// The responder is send with commands so that the backend has a way to comminicate with the
+/// The responder is send with commands so that the backend has a way to communicate with the
 /// frontend, without knowing about the frontend
 ///
 /// Only one is expected to be running at a time

--- a/src/frontend/app_command_responder.rs
+++ b/src/frontend/app_command_responder.rs
@@ -1,0 +1,106 @@
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context, Result};
+use swiftide::chat_completion;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::commands::{CommandResponse, Responder};
+
+use super::ui_event::UIEvent;
+
+static INSTANCE: OnceLock<Arc<AppCommandResponder>> = OnceLock::new();
+
+/// Handles responses from commands application wide
+///
+/// Basically converts command responses into UI events
+/// The responder is send with commands so that the backend has a way to comminicate with the
+/// frontend, without knowing about the frontend
+///
+/// Only one is expected to be running at a time
+#[derive(Debug, Clone)]
+pub struct AppCommandResponder {
+    // ui_tx: mpsc::UnboundedSender<UIEvent>,
+    tx: mpsc::UnboundedSender<CommandResponse>,
+    _handle: Arc<tokio::task::JoinHandle<()>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppCommandResponderForChatId {
+    inner: Arc<AppCommandResponder>,
+    uuid: uuid::Uuid,
+}
+
+impl AppCommandResponder {
+    pub fn init(ui_tx: mpsc::UnboundedSender<UIEvent>) -> Result<()> {
+        if INSTANCE.get().is_some() {
+            anyhow::bail!("App command responder already initialized");
+        }
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            while let Some(response) = rx.recv().await {
+                let ui_event = match response {
+                    CommandResponse::Chat(uuid, msg) => UIEvent::ChatMessage(uuid, msg.into()),
+                    CommandResponse::ActivityUpdate(uuid, state) => {
+                        UIEvent::ActivityUpdate(uuid, state)
+                    }
+                    CommandResponse::RenameChat(uuid, name) => UIEvent::RenameChat(uuid, name),
+                    CommandResponse::Completed(uuid) => UIEvent::CommandDone(uuid),
+                };
+
+                if let Err(err) = ui_tx.send(ui_event) {
+                    tracing::error!("Failed to send response to ui: {:#}", err);
+                }
+            }
+        });
+
+        // Create the app responder, spawn a task to handle responses, the once cell returns a
+        // clone of the responder without the rx
+        INSTANCE
+            .set(Arc::new(AppCommandResponder {
+                tx,
+                _handle: handle.into(),
+            }))
+            .map_err(|_| anyhow::anyhow!("Failed to set global frontend command responder"))?;
+
+        Ok(())
+    }
+
+    pub fn for_chat_id(uuid: Uuid) -> Arc<dyn Responder> {
+        let inner = INSTANCE
+            .get()
+            .expect("App command responder not initialized")
+            .clone();
+
+        Arc::new(AppCommandResponderForChatId { inner, uuid }) as Arc<dyn Responder>
+    }
+}
+
+impl Responder for AppCommandResponderForChatId {
+    fn handle(&self, response: CommandResponse) {
+        let response = response.with_uuid(self.uuid);
+        if let Err(err) = self.inner.tx.send(response) {
+            tracing::error!("Failed to send response for command: {:?}", err);
+        }
+    }
+
+    fn system_message(&self, message: &str) {
+        self.handle(CommandResponse::Chat(
+            self.uuid,
+            chat_completion::ChatMessage::new_system(message),
+        ));
+    }
+
+    fn update(&self, state: &str) {
+        self.handle(CommandResponse::ActivityUpdate(self.uuid, state.into()));
+    }
+
+    fn rename(&self, name: &str) {
+        self.handle(CommandResponse::RenameChat(self.uuid, name.into()));
+    }
+
+    fn agent_message(&self, message: chat_completion::ChatMessage) {
+        self.handle(CommandResponse::Chat(self.uuid, message));
+    }
+}

--- a/src/frontend/chat_mode/on_key.rs
+++ b/src/frontend/chat_mode/on_key.rs
@@ -97,10 +97,10 @@ pub fn handle_input_command(app: &mut App) -> ChatMessage {
     let current_input = app.text_input.lines().join("\n");
 
     let Ok(cmd) = UserInputCommand::parse_from_input(&current_input) else {
-        return ChatMessage::new_system("Unknown command").to_owned();
+        return ChatMessage::new_system("Unknown command").clone();
     };
 
-    let message = ChatMessage::new_command(cmd.as_ref()).to_owned();
+    let message = ChatMessage::new_command(cmd.as_ref()).clone();
 
     app.send_ui_event(UIEvent::UserInputCommand(app.current_chat_uuid, cmd));
 

--- a/src/frontend/chat_mode/on_key.rs
+++ b/src/frontend/chat_mode/on_key.rs
@@ -1,9 +1,9 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::{
-    chat_message::{ChatMessage, ChatMessageBuilder},
+    chat_message::ChatMessage,
     commands::Command,
-    frontend::{App, UIEvent, UserInputCommand},
+    frontend::{ui_event::UIEvent, ui_input_command::UserInputCommand, App},
 };
 
 pub fn on_key(app: &mut App, key: KeyEvent) {
@@ -19,17 +19,17 @@ pub fn on_key(app: &mut App, key: KeyEvent) {
         let message = if current_input.starts_with('/') {
             handle_input_command(app)
         } else {
-            app.dispatch_command(&Command::Chat {
-                message: current_input.clone(),
-                uuid: app.current_chat_uuid,
-            });
+            app.dispatch_command(
+                app.current_chat_uuid,
+                Command::Chat {
+                    message: current_input.clone(),
+                },
+            );
 
-            ChatMessage::new_user(&current_input)
-                .uuid(app.current_chat_uuid)
-                .to_owned()
+            ChatMessage::new_user(current_input)
         };
 
-        app.send_ui_event(message);
+        app.send_ui_event(UIEvent::ChatMessage(app.current_chat_uuid, message));
 
         app.reset_text_input();
 
@@ -42,9 +42,7 @@ pub fn on_key(app: &mut App, key: KeyEvent) {
             .modifiers
             .contains(crossterm::event::KeyModifiers::CONTROL)
     {
-        app.dispatch_command(&Command::StopAgent {
-            uuid: app.current_chat_uuid,
-        });
+        app.dispatch_command(app.current_chat_uuid, Command::StopAgent);
         return;
     }
 
@@ -95,29 +93,16 @@ pub fn on_key(app: &mut App, key: KeyEvent) {
     }
 }
 
-pub fn handle_input_command(app: &mut App) -> ChatMessageBuilder {
+pub fn handle_input_command(app: &mut App) -> ChatMessage {
     let current_input = app.text_input.lines().join("\n");
 
     let Ok(cmd) = UserInputCommand::parse_from_input(&current_input) else {
-        return ChatMessage::new_system("Unknown command")
-            .uuid(app.current_chat_uuid)
-            .to_owned();
+        return ChatMessage::new_system("Unknown command").to_owned();
     };
 
-    if let Some(cmd) = cmd.to_command(app.current_chat_uuid) {
-        // If the backend supports it, forward the command
-        app.dispatch_command(&cmd);
-    } else if let Ok(cmd) = UIEvent::try_from(cmd.clone()) {
-        app.send_ui_event(cmd);
-    } else {
-        tracing::error!("Could not convert ui command to backend command nor ui event {cmd}");
-        return ChatMessage::new_system("Unknown command")
-            .uuid(app.current_chat_uuid)
-            .to_owned();
-    }
+    let message = ChatMessage::new_command(cmd.as_ref()).to_owned();
 
-    ChatMessage::new_command(cmd.as_ref())
-        .uuid(app.current_chat_uuid)
-        .to_owned()
-    // Display the command as a message
+    app.send_ui_event(UIEvent::UserInputCommand(app.current_chat_uuid, cmd));
+
+    message
 }

--- a/src/frontend/mod.rs
+++ b/src/frontend/mod.rs
@@ -6,6 +6,7 @@ mod splash;
 mod ui_event;
 mod ui_input_command;
 
+mod app_command_responder;
 /// Different frontend ui modes
 mod chat_mode;
 mod logs_mode;
@@ -13,5 +14,5 @@ mod logs_mode;
 /// Let's be very strict about what to export
 /// to avoid coupling frontend and the rest
 pub use app::App;
-pub use ui_event::UIEvent;
-pub use ui_input_command::UserInputCommand;
+// pub use ui_event::UIEvent;
+// pub use ui_input_command::UserInputCommand;

--- a/src/frontend/ui_event.rs
+++ b/src/frontend/ui_event.rs
@@ -42,17 +42,3 @@ impl From<KeyEvent> for UIEvent {
         Self::Input(key)
     }
 }
-
-impl TryFrom<UserInputCommand> for UIEvent {
-    type Error = anyhow::Error;
-
-    fn try_from(value: UserInputCommand) -> Result<Self, Self::Error> {
-        match value {
-            UserInputCommand::NextChat => Ok(Self::NextChat),
-            UserInputCommand::NewChat => Ok(Self::NewChat),
-            UserInputCommand::Copy => Ok(Self::CopyLastMessage),
-            UserInputCommand::DeleteChat => Ok(Self::DeleteChat),
-            _ => anyhow::bail!("Cannot convert {value} to UIEvent"),
-        }
-    }
-}

--- a/src/frontend/ui_event.rs
+++ b/src/frontend/ui_event.rs
@@ -6,7 +6,7 @@ use crate::chat_message::ChatMessage;
 use super::{app::AppMode, ui_input_command::UserInputCommand};
 
 // Event handling
-#[derive(Debug, Clone, strum::Display)]
+#[derive(Debug, Clone, strum::Display, PartialEq)]
 #[allow(dead_code)]
 pub enum UIEvent {
     /// A key is pressed

--- a/src/frontend/ui_event.rs
+++ b/src/frontend/ui_event.rs
@@ -1,9 +1,9 @@
 use crossterm::event::KeyEvent;
 use uuid::Uuid;
 
-use crate::chat_message::{ChatMessage, ChatMessageBuilder};
+use crate::chat_message::ChatMessage;
 
-use super::{app::AppMode, UserInputCommand};
+use super::{app::AppMode, ui_input_command::UserInputCommand};
 
 // Event handling
 #[derive(Debug, Clone, strum::Display)]
@@ -14,7 +14,7 @@ pub enum UIEvent {
     /// A frontend tick event to trigger updates, etc
     Tick,
     /// A chat message is received
-    ChatMessage(ChatMessage),
+    ChatMessage(Uuid, ChatMessage),
     /// Start a new chat
     NewChat,
     /// Switch to the next chat
@@ -33,24 +33,8 @@ pub enum UIEvent {
     CopyLastMessage,
     /// Deletes the current chat
     DeleteChat,
-}
-
-impl From<ChatMessage> for UIEvent {
-    fn from(msg: ChatMessage) -> Self {
-        Self::ChatMessage(msg)
-    }
-}
-
-impl From<ChatMessageBuilder> for UIEvent {
-    fn from(mut builder: ChatMessageBuilder) -> Self {
-        Self::ChatMessage(builder.build())
-    }
-}
-
-impl From<&mut ChatMessageBuilder> for UIEvent {
-    fn from(builder: &mut ChatMessageBuilder) -> Self {
-        Self::ChatMessage(builder.build().clone())
-    }
+    /// Received a user command (prefixed with '/') from the user
+    UserInputCommand(Uuid, UserInputCommand),
 }
 
 impl From<KeyEvent> for UIEvent {

--- a/src/frontend/ui_input_command.rs
+++ b/src/frontend/ui_input_command.rs
@@ -21,6 +21,7 @@ pub enum UserInputCommand {
     NewChat,
     DeleteChat,
     Copy,
+    #[strum(disabled)] // <-- Different PR
     Diff(DiffVariant),
 }
 
@@ -111,6 +112,7 @@ mod tests {
         }
     }
 
+    #[ignore = "future pull request"]
     #[test]
     fn test_parse_diff_input() {
         let test_cases = vec![

--- a/src/frontend/ui_input_command.rs
+++ b/src/frontend/ui_input_command.rs
@@ -44,12 +44,15 @@ pub enum DiffVariant {
 }
 
 impl UserInputCommand {
+    /// Convenience method to turn a `UserInputCommand` into a `Command`
+    ///
+    /// Not all user input commands can be turned into a `Command`
     #[must_use]
-    pub fn to_command(&self, uuid: Uuid) -> Option<Command> {
+    pub fn to_command(&self) -> Option<Command> {
         match self {
-            UserInputCommand::Quit => Some(Command::Quit { uuid }),
-            UserInputCommand::ShowConfig => Some(Command::ShowConfig { uuid }),
-            UserInputCommand::IndexRepository => Some(Command::IndexRepository { uuid }),
+            UserInputCommand::Quit => Some(Command::Quit),
+            UserInputCommand::ShowConfig => Some(Command::ShowConfig),
+            UserInputCommand::IndexRepository => Some(Command::IndexRepository),
             _ => None,
         }
     }

--- a/src/frontend/ui_input_command.rs
+++ b/src/frontend/ui_input_command.rs
@@ -1,6 +1,5 @@
 use crate::commands::Command;
 use anyhow::{Context as _, Result};
-use uuid::Uuid;
 
 #[derive(
     Debug,

--- a/src/frontend/ui_input_command.rs
+++ b/src/frontend/ui_input_command.rs
@@ -1,6 +1,8 @@
 use crate::commands::Command;
 use anyhow::{Context as _, Result};
 
+use super::ui_event::UIEvent;
+
 #[derive(
     Debug,
     Clone,
@@ -53,6 +55,20 @@ impl UserInputCommand {
             UserInputCommand::Quit => Some(Command::Quit),
             UserInputCommand::ShowConfig => Some(Command::ShowConfig),
             UserInputCommand::IndexRepository => Some(Command::IndexRepository),
+            _ => None,
+        }
+    }
+
+    /// Convenience method to turn a `UserInputCommand` into a `UIEvent`
+    ///
+    /// Not all user input commands can be turned into a `UIEvent`
+    #[must_use]
+    pub fn to_ui_event(&self) -> Option<UIEvent> {
+        match self {
+            UserInputCommand::NextChat => Some(UIEvent::NextChat),
+            UserInputCommand::NewChat => Some(UIEvent::NewChat),
+            UserInputCommand::Copy => Some(UIEvent::CopyLastMessage),
+            UserInputCommand::DeleteChat => Some(UIEvent::DeleteChat),
             _ => None,
         }
     }

--- a/src/indexing/repository.rs
+++ b/src/indexing/repository.rs
@@ -162,7 +162,7 @@ pub async fn index_repository(
 struct UiUpdater(Option<Arc<dyn Responder>>);
 
 impl UiUpdater {
-    async fn send_update(&self, state: impl AsRef<str>) {
+    fn send_update(&self, state: impl AsRef<str>) {
         let Some(responder) = &self.0 else { return };
         responder.update(state.as_ref());
     }

--- a/src/indexing/repository.rs
+++ b/src/indexing/repository.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-use crate::commands::CommandResponder;
+use crate::commands::Responder;
 use crate::repository::Repository;
 use crate::storage;
 use anyhow::Result;
@@ -23,7 +23,7 @@ const MARKDOWN_CHUNK_RANGE: std::ops::Range<usize> = 100..1024;
 #[tracing::instrument(skip_all)]
 pub async fn index_repository(
     repository: &Repository,
-    responder: Option<CommandResponder>,
+    responder: Option<Arc<dyn Responder>>,
 ) -> Result<()> {
     let updater = UiUpdater::from(responder);
 
@@ -159,17 +159,17 @@ pub async fn index_repository(
 
 // Just a simple wrapper so we can avoid having to Option check all the time
 #[derive(Debug, Clone)]
-struct UiUpdater(Option<CommandResponder>);
+struct UiUpdater(Option<Arc<dyn Responder>>);
 
 impl UiUpdater {
-    fn send_update(&self, state: impl Into<String>) {
+    async fn send_update(&self, state: impl AsRef<str>) {
         let Some(responder) = &self.0 else { return };
-        responder.send_update(state);
+        responder.update(state.as_ref());
     }
 }
 
-impl From<Option<CommandResponder>> for UiUpdater {
-    fn from(responder: Option<CommandResponder>) -> Self {
+impl From<Option<Arc<dyn Responder>>> for UiUpdater {
+    fn from(responder: Option<Arc<dyn Responder>>) -> Self {
         Self(responder)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ async fn start_agent(mut repository: repository::Repository, initial_message: &s
     });
 
     let query = initial_message.to_string();
-    let mut agent =
+    let (mut agent, _) =
         agent::build_agent(Uuid::new_v4(), &repository, &query, responder_for_agent).await?;
 
     agent.query(&query).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use config::Config;
 use frontend::App;
 use git::github::GithubSession;
 use kwaak::{
-    agent, chat_message, cli, commands, config, frontend, git,
+    agent, cli, commands, config, frontend, git,
     indexing::{self, index_repository},
     onboarding, repository, storage,
 };


### PR DESCRIPTION
Reworks command handling such that it always takes a dynamic responder. This PR is a big enabler, making a lot of features on the roadmap easier to implement.

This allows full decoupling with command handling from the responder, making it easier to implement features like getting the diff from a running agent.

For the latter, this PR contains a few changes in prep for that as well.
