### PR TITLE
feat: Add ctrl+enter and shift+enter as shortcuts to send a message

### DIFF
--- a/src/frontend/chat_mode/on_key.rs
+++ b/src/frontend/chat_mode/on_key.rs
@@ -9,12 +9,20 @@ use crate::{
 pub fn on_key(app: &mut App, key: &KeyEvent) {
     let current_input = app.text_input.lines().join("\n");
 
-    // `Ctrl-s` to send the message in the text input
-    if key.code == KeyCode::Char('s')
+    // `Ctrl-Enter` or `Shift-Enter` or `Ctrl-s` to send the message in the text input
+    if (key.code == KeyCode::Char('s')
         && key
             .modifiers
-            .contains(crossterm::event::KeyModifiers::CONTROL)
-        && !current_input.is_empty()
+            .contains(crossterm::event::KeyModifiers::CONTROL))
+        || (key.code == KeyCode::Enter
+            && key
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::CONTROL))
+        || (key.code == KeyCode::Enter
+            && key
+                .modifiers
+                .contains(crossterm::event::KeyModifiers::SHIFT))
+            && !current_input.is_empty()
     {
         let message = if current_input.starts_with('/') {
             handle_input_command(app)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ use ratatui::{
 
 use ::tracing::instrument;
 use crossterm::{
+    event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -136,7 +137,7 @@ async fn test_tool(
     Ok(())
 }
 
-#[instrument]
+#[instrument(skip_all)]
 async fn start_agent(mut repository: repository::Repository, initial_message: &str) -> Result<()> {
     repository.config_mut().endless_mode = true;
 
@@ -171,7 +172,7 @@ async fn start_agent(mut repository: repository::Repository, initial_message: &s
     Ok(())
 }
 
-#[instrument]
+#[instrument(skip_all)]
 async fn start_tui(repository: &repository::Repository, args: &cli::Args) -> Result<()> {
     ::tracing::info!("Loaded configuration: {:?}", repository.config());
 
@@ -239,6 +240,10 @@ pub fn init_panic_hook() {
 pub fn init_tui() -> io::Result<Terminal<impl Backend>> {
     enable_raw_mode()?;
     execute!(stdout(), EnterAlternateScreen)?;
+    execute!(
+        stdout(),
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::all())
+    )?;
     Terminal::new(CrosstermBackend::new(stdout()))
 }
 
@@ -250,5 +255,6 @@ pub fn init_tui() -> io::Result<Terminal<impl Backend>> {
 pub fn restore_tui() -> io::Result<()> {
     disable_raw_mode()?;
     execute!(stdout(), LeaveAlternateScreen)?;
+    execute!(stdout(), PopKeyboardEnhancementFlags)?;
     Ok(())
 }


### PR DESCRIPTION
Implemented additional keyboard shortcuts `ctrl+enter` and `shift+enter` for sending messages to the agent, alongside the existing `ctrl+s` functionality. This change enhances user convenience by allowing multiple key combinations to trigger the same action.

---

_This pull request was created by [kwaak](https://github.com/bosun-ai/kwaak), a free, open-source, autonomous coding agent tool. Pull requests are tracked in bosun-ai/kwaak#48_

