### PR TITLE
feat: Adjust arrow key behavior in chat input

### DIFF
--- a/src/frontend/chat_mode/on_key.rs
+++ b/src/frontend/chat_mode/on_key.rs
@@ -67,6 +67,17 @@ pub fn on_key(app: &mut App, key: &KeyEvent) {
         KeyCode::PageUp => {
             app.send_ui_event(UIEvent::ScrollUp);
         }
+        KeyCode::Up | KeyCode::Down | KeyCode::Left | KeyCode::Right => {
+            if current_input.is_empty() {
+                match key.code {
+                    KeyCode::Up => app.send_ui_event(UIEvent::ScrollUp),
+                    KeyCode::Down => app.send_ui_event(UIEvent::ScrollDown),
+                    _ => {} // Handle other arrow keys if needed
+                }
+            } else {
+                app.text_input.input(*key);
+            }
+        }
         _ => {
             app.text_input.input(*key);
         }


### PR DESCRIPTION
The modification alters how the arrow keys are handled within the chat mode of the application. We want the arrow keys to scroll the chat history only when the input box is empty. When there is content in the chat input, the arrow key presses are directed to text navigation operations within the input box. 

### Modifications
- In `src/frontend/chat_mode/on_key.rs`, enhanced the checks under the `match` expression.
- Ensure up and down keys handle scrolling for empty input.
- Route key presses for navigation to text input when there's content in the `current_input`.

### Results
- All tests passed successfully post-modification.

---

_This pull request was created by [kwaak](https://github.com/bosun-ai/kwaak), a free, open-source, autonomous coding agent tool. Pull requests are tracked in bosun-ai/kwaak#48_

