### PR TITLE
feat: Use the git diff to steer on test and coverage results

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ All of these are inferred from the project directory and can be overridden in th
 
 #### Command Configuration
 
-Kwaak uses tests, coverages, and lints as an additional oppertunity to steer the agent. Configuring these will (significantly) improve the agents' performance.
+Kwaak uses tests, coverages, and lints as an additional opportunity to steer the agent. Configuring these will (significantly) improve the agents' performance.
 
 - **`test`**: Command to run tests, e.g., `cargo test`.
 - **`coverage`**: Command for running coverage checks, e.g., `cargo llvm-cov --summary-only`. Expects coverage results as output. Currently handled unparsed via an LLM call. A friendly output is preferred

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ All of these are inferred from the project directory and can be overridden in th
 
 #### Command Configuration
 
+Kwaak uses tests, coverages, and lints as an additional oppertunity to steer the agent. Configuring these will (significantly) improve the agents' performance.
+
 - **`test`**: Command to run tests, e.g., `cargo test`.
 - **`coverage`**: Command for running coverage checks, e.g., `cargo llvm-cov --summary-only`. Expects coverage results as output. Currently handled unparsed via an LLM call. A friendly output is preferred
 - **`lint_and_fix`**: Optional command to lint and fix project issues, e.g., `cargo clippy --fix --allow-dirty; cargo fmt` in Rust.

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -133,7 +133,7 @@ impl ConversationSummarizer {
         * If the goal is not yet achieved, reflect on why and provide a clear path forward
 
         {{% if diff -%}}
-        # Current changes made
+        ## Current changes made
         ````
         {{{{ diff }}}}
         ````

--- a/src/agent/snapshots/kwaak__agent__tool_summarizer__test__prompt_rendering.snap
+++ b/src/agent/snapshots/kwaak__agent__tool_summarizer__test__prompt_rendering.snap
@@ -1,0 +1,51 @@
+---
+source: src/agent/tool_summarizer.rs
+expression: rendered_prompt.render().await.unwrap()
+---
+# Goal
+A coding agent has made a tool call. It is your job to refine the output.
+
+Reformat the following tool output such that it is effective for a chatgpt agent to work with. Only include the reformatted output in your response.
+Reformat but do not summarize, all information should be preserved and detailed.
+
+## 
+Tool name: search_file
+Tool description: Searches for a file inside the current project, leave the argument empty to list all files. Uses `find`.
+Tool was called with arguments: {"query":"some_file"}
+
+
+
+## The agent has made the following changes
+````
+diff --git a/some_file b/some_file
+index 0000000..1111111 100644
+--- a/some_file
++++ b/some_file
+@@ -1,1 +1,1 @@
+-old
++new
+    
+````
+
+
+## Tool output
+```
+Found it!
+```
+
+## Format
+* Only include the reformatted output in your response and nothing else.
+* Include clear instructions on how to fix each issue using the tools that are
+  available only.
+* If you do not have a clear solution, state that you do not have a clear solution.
+* If there is any mangling in the tool response, reformat it to be readable.
+* If you suspect that any changes made by the agent affect the tool output, mention
+    that. Make sure you include full paths to the files.
+## Available tools
+- **search_file**: Searches for a file inside the current project, leave the argument empty to list all files. Uses `find`.
+
+## Requirements
+* Only propose improvements that can be fixed by the tools and functions that are
+    available in the conversation. For instance, running a command to fix linting can also be fixed by writing to that file without errors.
+* If the tool output has repeating patterns, only include the pattern once and state
+ that it happens multiple times.

--- a/src/agent/tool_summarizer.rs
+++ b/src/agent/tool_summarizer.rs
@@ -9,7 +9,7 @@ use swiftide::{
 };
 use tracing::Instrument as _;
 
-use crate::{git, util::accept_non_zero_exit};
+use crate::util::accept_non_zero_exit;
 
 #[derive(Clone)]
 pub struct ToolSummarizer<'a> {
@@ -107,10 +107,7 @@ fn prompt(
         .join("\n");
 
     let additional_instructions = if tool_call.name() == "run_tests"
-        && available_tools
-            .iter()
-            .find(|t| t.name() == "run_coverage")
-            .is_some()
+        && available_tools.iter().any(|t| t.name() == "run_coverage")
     {
         indoc::formatdoc! {"
                 ## Additional instructions

--- a/src/agent/tool_summarizer.rs
+++ b/src/agent/tool_summarizer.rs
@@ -4,15 +4,19 @@ use swiftide::{
     agents::hooks::AfterToolFn,
     chat_completion::{Tool, ToolCall, ToolOutput},
     prompt::Prompt,
+    traits::Command,
     traits::SimplePrompt,
 };
 use tracing::Instrument as _;
+
+use crate::{git, util::accept_non_zero_exit};
 
 #[derive(Clone)]
 pub struct ToolSummarizer<'a> {
     llm: Arc<dyn SimplePrompt>,
     tools_to_summarize: Vec<&'a str>,
     available_tools: Vec<Box<dyn Tool>>,
+    git_start_sha: String,
 }
 
 impl<'a> ToolSummarizer<'a> {
@@ -20,11 +24,13 @@ impl<'a> ToolSummarizer<'a> {
         llm: Box<dyn SimplePrompt>,
         tools_to_summarize: &[&'a str],
         available_tools: &[Box<dyn Tool>],
+        git_start_sha: impl Into<String>,
     ) -> Self {
         Self {
             llm: llm.into(),
             tools_to_summarize: tools_to_summarize.into(),
             available_tools: available_tools.into(),
+            git_start_sha: git_start_sha.into(),
         }
     }
 
@@ -34,7 +40,7 @@ impl<'a> ToolSummarizer<'a> {
     where
         'a: 'b,
     {
-        move |_context, tool_call, tool_output| {
+        move |context, tool_call, tool_output| {
             let llm = self.llm.clone();
 
             let Some(tool) = self
@@ -47,11 +53,30 @@ impl<'a> ToolSummarizer<'a> {
             };
 
             if let Ok(output) = tool_output {
-                let prompt = self.prompt(tool, tool_call, output);
+                let git_start_sha = self.git_start_sha.clone();
 
                 let span = tracing::info_span!("summarize_tool", tool = tool.name());
+                let prompt = prompt(tool, tool_call, output, self.available_tools.as_slice());
+
                 return Box::pin(
                     async move {
+                        let current_diff = accept_non_zero_exit(
+                            context
+                                .exec_cmd(&Command::shell(format!(
+                                    "git diff {git_start_sha} --no-color"
+                                )))
+                                .await,
+                        )?
+                        .output;
+
+                        let current_diff = if current_diff.is_empty() {
+                            None
+                        } else {
+                            Some(current_diff)
+                        };
+
+                        let prompt = prompt.with_context_value("diff", current_diff);
+
                         let summary = llm.prompt(prompt).await?;
                         tracing::debug!(summary = %summary, original = %output, "Summarized tool output");
                         *output = summary.into();
@@ -65,38 +90,59 @@ impl<'a> ToolSummarizer<'a> {
         }
     }
 
-    fn prompt(&self, tool: &dyn Tool, tool_call: &ToolCall, tool_output: &ToolOutput) -> Prompt {
-        let available_tools = self
-            .available_tools
-            .iter()
-            .map(|tool| format!("- **{}**: {}", tool.name(), tool.tool_spec().description))
-            .collect::<Vec<String>>()
-            .join("\n");
+    // tfw changing to jinja halfway through
+    // The older prompts (like these) are a mess. It would be so nice to have everything in
+    // templates and use partials.
+}
+fn prompt(
+    tool: &dyn Tool,
+    tool_call: &ToolCall,
+    tool_output: &ToolOutput,
+    available_tools: &[Box<dyn Tool>],
+) -> Prompt {
+    let formatted_tools = available_tools
+        .iter()
+        .map(|tool| format!("- **{}**: {}", tool.name(), tool.tool_spec().description))
+        .collect::<Vec<String>>()
+        .join("\n");
 
-        // NOTE: Argument to split up the agent into role dedicated agents
-        let additional_instructions = if tool_call.name() == "run_tests" {
-            indoc::formatdoc! {"
+    let additional_instructions = if tool_call.name() == "run_tests"
+        && available_tools
+            .iter()
+            .find(|t| t.name() == "run_coverage")
+            .is_some()
+    {
+        indoc::formatdoc! {"
                 ## Additional instructions
                 * If the tests pass, additionally mention that coverage must be checked such that
                   it actually improved, did not stay the same, and the file executed properly.
             "}
-        } else {
-            String::new()
-        };
+    } else {
+        String::new()
+    };
 
-        let prompt = indoc::formatdoc!(
+    indoc::formatdoc!(
             "
             # Goal
+            A coding agent has made a tool call. It is your job to refine the output.
+
             Reformat the following tool output such that it is effective for a chatgpt agent to work with. Only include the reformatted output in your response.
             Reformat but do not summarize, all information should be preserved and detailed.
     
-            ## Additional Context
+            ## 
             Tool name: {tool_name}
             Tool description: {tool_description}
             Tool was called with arguments: {tool_args}
 
             {additional_instructions}
     
+            {{% if diff -%}}
+            ## The agent has made the following changes
+            ````
+            {{{{ diff }}}}
+            ````
+            {{% endif %}}
+
             ## Tool output
             ```
             {tool_output}
@@ -108,19 +154,63 @@ impl<'a> ToolSummarizer<'a> {
               available only.
             * If you do not have a clear solution, state that you do not have a clear solution.
             * If there is any mangling in the tool response, reformat it to be readable.
+            {{% if diff -%}}
+            * If you suspect that any changes made by the agent affect the tool output, mention
+                that. Make sure you include full paths to the files.
+            {{% endif -%}}
     
             ## Available tools
-            {available_tools}
+            {formatted_tools}
 
             ## Requirements
             * Only propose improvements that can be fixed by the tools and functions that are
                 available in the conversation. For instance, running a command to fix linting can also be fixed by writing to that file without errors.
             * If the tool output has repeating patterns, only include the pattern once and state
              that it happens multiple times.
-            ", tool_name = tool.name(), tool_description = tool.tool_spec().description, tool_args = tool_call.args().unwrap_or_default(), tool_output = tool_output.content().unwrap_or_default());
+            ", tool_name = tool.name(), tool_description = tool.tool_spec().description, tool_args = tool_call.args().unwrap_or_default(), tool_output = tool_output.content().unwrap_or_default().replace('{', "\\{")).into()
+}
 
-        // Escape any accidental jinja style formatting
-        // Shouldn't be an issue in latest swiftide though, but just in case
-        prompt.replace('{', "\\{").into()
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use crate::agent::tools::search_file;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_prompt_rendering() {
+        let tool = search_file();
+
+        let tool_call = ToolCall::builder()
+            .name("search_file")
+            .id("1")
+            .args(json!({ "query": "some_file"}).to_string())
+            .build()
+            .unwrap();
+        let tool_output = ToolOutput::Text("Found it!".into());
+
+        let available_tools = vec![Box::new(tool) as Box<dyn Tool>];
+        let diff = indoc::indoc!(
+            "
+            diff --git a/some_file b/some_file
+            index 0000000..1111111 100644
+            --- a/some_file
+            +++ b/some_file
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+                "
+        );
+
+        let rendered_prompt = prompt(
+            &available_tools[0],
+            &tool_call,
+            &tool_output,
+            &available_tools,
+        )
+        .with_context_value("diff", diff);
+
+        insta::assert_snapshot!(rendered_prompt.render().await.unwrap());
     }
 }

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -154,8 +154,12 @@ pub async fn start_agent(
     let tx_3 = command_responder.clone();
     let tx_4 = command_responder.clone();
 
-    let tool_summarizer =
-        ToolSummarizer::new(fast_query_provider, &["run_tests", "run_coverage"], &tools);
+    let tool_summarizer = ToolSummarizer::new(
+        fast_query_provider,
+        &["run_tests", "run_coverage"],
+        &tools,
+        &agent_env.start_ref,
+    );
     let conversation_summarizer =
         ConversationSummarizer::new(query_provider.clone(), &tools, &agent_env.start_ref);
     let maybe_lint_fix_command = repository.config().commands.lint_and_fix.clone();

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Result;
-use swiftide_core::Tool;
 use tokio::{
     sync::{mpsc, RwLock},
     task::{self},

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::Result;
+use swiftide_core::Tool;
 use tokio::{
     sync::{mpsc, RwLock},
     task::{self},
@@ -144,7 +145,7 @@ impl CommandHandler {
                 };
 
                 let base_sha = &agent.agent_environment.start_ref;
-                let diff = git::util::diff(agent.executor.as_ref(), &base_sha).await?;
+                let diff = git::util::diff(agent.executor.as_ref(), &base_sha, true).await?;
 
                 event.responder().system_message(&diff);
             }

--- a/src/git/util.rs
+++ b/src/git/util.rs
@@ -6,8 +6,9 @@ use swiftide_core::{Command, ToolExecutor};
 use crate::util::accept_non_zero_exit;
 
 /// Get the diff from a tool executor
-pub async fn diff(executor: &dyn ToolExecutor, base_sha: &str) -> Result<String> {
-    let cmd = Command::shell(format!("git diff --color=always {base_sha}",));
+pub async fn diff(executor: &dyn ToolExecutor, base_sha: &str, color: bool) -> Result<String> {
+    let color = if color { "--color=always" } else { "" };
+    let cmd = Command::shell(format!("git diff {color} {base_sha}",));
 
     let mut output = accept_non_zero_exit(executor.exec_cmd(&cmd).await)?.output;
 


### PR DESCRIPTION
Sometimes agents lose context of what they were working on. Now when tests results are summarized, it is combined with the git diff since the agent started. Heuristically appears to help with #182 