### PR TITLE
feat: Reworked, opt-in line editing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6879,9 +6879,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85554c1fd22fb137e6ed9583cd82198bb077c50b6d8944092bb4e165a8dd3b3c"
+checksum = "6d6aebd38f4802f8dc24ba45a3d01fbe87253f89c991048454019b1f4ac213bb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6919,9 +6919,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71d2d07cba275ed852accf0cbe307b2e21bdcb5ba3824285e91b3842d229be2"
+checksum = "fa9988019e32b8954e9377a9a2ef2875d5bbfb7f9d246fe6bdf9f86ebc50c9e8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7033,9 +7033,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.17.4"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85aa73792efdf26c4ffd8f9b954a52c4e5fdd9a752b9445eb5cf45b53e1f43d0"
+checksum = "f9515c469a1eeac6e4b570108716d9ca644b04fefaf1f7dbdc139b01387a8f66"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tokio-util = { version = "0.7.13", features = ["rt"] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
 swiftide-docker-executor = "0.4.1"
-swiftide = { version = "0.17.4", features = [
+swiftide = { version = "0.17.5", features = [
   "lancedb",
   "openai",
   "tree-sitter",
@@ -29,8 +29,7 @@ swiftide = { version = "0.17.4", features = [
   "swiftide-agents",
 
 ] }
-swiftide-core = { version = "0.17.4" }
-swiftide-macros = { version = "0.17.4" }
+swiftide-macros = { version = "0.17.5" }
 toml = "0.8.19"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
@@ -104,7 +103,7 @@ test-log = { version = "0.2.16", features = ["trace"] }
 insta = "1.41.1"
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
-swiftide-core = { version = "0.17.4", features = ["test-utils"] }
+swiftide-core = { version = "0.17.5", features = ["test-utils"] }
 mockall = "0.13.1"
 rexpect = "0.6.0"
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ These configurations allow you to leverage the strengths of each model effective
 - **`otel_enabled`**: Enables OpenTelemetry tracing if set and respects all the standard OpenTelemetry environment variables.
 - **`tool_executor`**: Defaults to `docker`. Can also be `local`. We **HIGHLY** recommend using `docker` for security reasons unless you are running in a secure environment.
 - **`tavily_api_key`**: Enables the agent to use [tavily](https://tavily.com) for web search. Their entry-level plan is free. (we are not affiliated)
+- `**agent_edit_mode**`: Defaults to `whole` (write full files at the time). If you experience issues with (very) large files, you can experiment with `line` edits.
 - **`git.auto_push_remote`**: Enabled by default if a github key is present. Automatically pushes to the remote repository after each chat completion. You can disable this by setting it to `false`.
 - **_`disabled_tools.pull_request`_**: Enables or disables the pull request tool. Defaults to `false`.
 

--- a/kwaak.toml
+++ b/kwaak.toml
@@ -8,9 +8,9 @@ tool_executor = "docker"
 otel_enabled = true
 
 [commands]
-test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo nextest run --no-fail-fast --color=never -- -q"
+test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo nextest run --no-fail-fast --color=never"
 coverage = "cargo +nightly llvm-cov nextest --no-clean --summary-only"
-lint_and_fix = "cargo clippy --fix --allow-dirty --allow-staged; cargo fmt"
+# lint_and_fix = "cargo clippy --fix --allow-dirty --allow-staged; cargo fmt"
 
 [git]
 owner = "bosun-ai"

--- a/kwaak.toml
+++ b/kwaak.toml
@@ -8,7 +8,7 @@ tool_executor = "docker"
 otel_enabled = true
 
 [commands]
-test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo nextest run --no-fail-fast --color=never"
+test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo nextest run --no-fail-fast --color=never -- -q"
 coverage = "cargo +nightly llvm-cov nextest --no-clean --summary-only"
 lint_and_fix = "cargo clippy --fix --allow-dirty --allow-staged; cargo fmt"
 

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -109,7 +109,18 @@ impl ConversationSummarizer {
         let available_tools = self
             .available_tools
             .iter()
-            .map(|tool| format!("- **{}**: {}", tool.name(), tool.tool_spec().description))
+            .map(|tool| {
+                format!(
+                    "- **{}**: {}",
+                    tool.name(),
+                    // Some tools have large descriptions, only take the first line
+                    tool.tool_spec()
+                        .description
+                        .lines()
+                        .take(1)
+                        .collect::<String>()
+                )
+            })
             .collect::<Vec<String>>()
             .join("\n");
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,9 +6,9 @@ pub mod tools;
 mod util;
 mod v1;
 use std::sync::Arc;
+use swiftide::chat_completion::Tool;
 
 use anyhow::Result;
-use swiftide_core::Tool;
 
 /// NOTE: On architecture, when more agents are added, it would be nice to have the concept of an
 /// (Agent/Chat) session that wraps all this complexity => Responders then update on the session.

--- a/src/agent/tool_summarizer.rs
+++ b/src/agent/tool_summarizer.rs
@@ -102,7 +102,18 @@ fn prompt(
 ) -> Prompt {
     let formatted_tools = available_tools
         .iter()
-        .map(|tool| format!("- **{}**: {}", tool.name(), tool.tool_spec().description))
+        .map(|tool| {
+            format!(
+                "- **{}**: {}",
+                tool.name(),
+                // Some tools have large descriptions, only take the first line
+                tool.tool_spec()
+                    .description
+                    .lines()
+                    .take(1)
+                    .collect::<String>()
+            )
+        })
         .collect::<Vec<String>>()
         .join("\n");
 

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -169,7 +169,7 @@ impl ResetFile {
     )
 )]
 pub async fn search_code(context: &dyn AgentContext, query: &str) -> Result<ToolOutput, ToolError> {
-    let cmd = Command::Shell(format!("rg -i. -F '{query}'"));
+    let cmd = Command::Shell(format!("rg -g '!.git' -i. -F '{query}'"));
     let output = accept_non_zero_exit(context.exec_cmd(&cmd).await)?;
     Ok(output.into())
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -625,5 +625,5 @@ pub async fn add_lines(
     let write_cmd = Command::WriteFile(file_name.into(), lines.join("\n"));
     context.exec_cmd(&write_cmd).await?;
 
-    Ok(format!("Successfully addded content to {file_name} at line {start_line}. Before making new edits, you MUST read the file again, as the line numbers WILL have changed.").into())
+    Ok(format!("Successfully added content to {file_name} at line {start_line}. Before making new edits, you MUST read the file again, as the line numbers WILL have changed.").into())
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -58,7 +58,7 @@ pub async fn read_file(
 
 // TODO: Better to have a single read_file tool with an optional line number flag
 #[tool(
-    description = "Reads file content, including line numbers. You MUST use this tool to retrieve line numbers before making a block edit with replace_block",
+    description = "Reads file content, including line numbers. You MUST use this tool to retrieve line numbers before making aedit with edit_file",
     param(name = "file_name", description = "Full path of the file")
 )]
 pub async fn read_file_with_line_numbers(
@@ -74,7 +74,7 @@ pub async fn read_file_with_line_numbers(
         .output
         .lines()
         .enumerate()
-        .map(|(i, l)| format!("{line_num}: {l}", line_num = i + 1));
+        .map(|(i, l)| format!("{line_num}|{l}", line_num = i + 1));
 
     Ok(lines.collect::<Vec<_>>().join("\n").into())
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -471,9 +471,9 @@ const EDIT_FILE_DESCRIPTION: &str = "Edit a file in plain-text format.
 You can use this tool to do the following:
 
 * Replace lines between a start and end line number (inclusive!)
-* Insert a new line AFTER a specific line number
+* Insert a new line AFTER a specific line number (set end_line to 0)
 * Remove lines by replacing them with an empty string
-* Append to an existing file
+* Append to an existing file (start_line to last line, end_line to 0)
 
 You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
 
@@ -497,7 +497,7 @@ To add text without replacing, set the `end_line` to 0. The content will be adde
     ),
     param(
         name = "end_line",
-        description = "End line number of the block to replace. Inclusive! End line will be replaced as well. Leave as 0 to append after the start line."
+        description = "End line number of the block to replace. Inclusive! End line will be replaced as well. Set to 0 to insert new content after the start line."
     ),
     param(name = "content", description = "Replacement content")
 )]

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -470,14 +470,12 @@ pub async fn fetch_url(_context: &dyn AgentContext, url: &str) -> Result<ToolOut
 const EDIT_FILE_DESCRIPTION: &str = "Edit a file in plain-text format.
 You can use this tool to do the following:
 
-* Replace a block of text with new content
+* Replace lines between a start and end line number (inclusive!)
 * Insert a new line AFTER a specific line number
 * Remove lines by replacing them with an empty string
 * Append to an existing file
 
 You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
-
-Line numbers start at 1 and ranges are inclusive.
 
 After editing, you MUST read the file again to get the new line numbers.
 
@@ -499,7 +497,7 @@ To add text without replacing, set the `end_line` to 0. The content will be adde
     ),
     param(
         name = "end_line",
-        description = "End line number of the block to replace. This is inclusive! End line will be replaced as well."
+        description = "End line number of the block to replace. Inclusive! End line will be replaced as well. Leave as 0 to append after the start line."
     ),
     param(name = "content", description = "Replacement content")
 )]

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -481,9 +481,6 @@ After editing, you MUST read the file again to get the new line numbers.
 
 If you intend to make multiple changes to a single file, you must read -> edit -> read -> edit -> read -> edit, etc.
 
-Prefer this over writing the full file content if you only need to change a small part of the file.
-This avoids unnecessary conflicts.
-
 You MUST respect the exact indentation and formatting of the file you are editing. For instance, Python code breaks if not indenting correctly.
 
 To add text without replacing, set the `end_line` to 0. The content will be added **after** that line.

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -475,10 +475,9 @@ You can use this tool to do the following:
 * Remove lines by replacing them with an empty string
 * Append to an existing file
 
-## Constraints
+You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
 
-**You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
-Line numbers start at 1 and ranges are inclusive.**
+Line numbers start at 1 and ranges are inclusive.
 
 After editing, you MUST read the file again to get the new line numbers.
 
@@ -488,8 +487,6 @@ Prefer this over writing the full file content if you only need to change a smal
 This avoids unnecessary conflicts.
 
 You MUST respect the exact indentation and formatting of the file you are editing. For instance, Python code breaks if not indenting correctly.
-
-You cannot call this tool more than once on a file, without reading the line numbers again.
 
 To add text without replacing, set the `end_line` to 0. The content will be added **after** that line.
 ";

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -468,11 +468,11 @@ pub async fn fetch_url(_context: &dyn AgentContext, url: &str) -> Result<ToolOut
 }
 
 #[tool(
-    description = "Replace lines in a file. You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace. After editing, you MUST read the file again to get the new line numbers.",
+    description = "Replace lines in a file. You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace. After editing, you MUST read the file again to get the new line numbers. If you want to add lines, use `add_lines` instead",
     param(name = "file_name", description = "Full path of the file"),
     param(
         name = "start_line",
-        description = "Start line number of the block to replace"
+        description = "Start line number of the lines to replace"
     ),
     param(
         name = "end_line",
@@ -539,13 +539,13 @@ pub async fn replace_lines(
 }
 
 #[tool(
-    description = "Insert new lines after a specific line number. You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace. After editing, you MUST read the file again to get the new line numbers.",
+    description = "Add new lines after a specific line number. You MUST read the file with line numbers first BEFORE EVERY EDIT, to know after what line number to add. After adding lines, you MUST read the file again to get the new line numbers.",
     param(name = "file_name", description = "Full path of the file"),
     param(
         name = "start_line",
         description = "The line number to insert the content after"
     ),
-    param(name = "content", description = "Replacement content")
+    param(name = "content", description = "New content")
 )]
 pub async fn add_lines(
     context: &dyn AgentContext,

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -467,8 +467,45 @@ pub async fn fetch_url(_context: &dyn AgentContext, url: &str) -> Result<ToolOut
         .map(Into::into)
 }
 
+const REPLACE_LINES_DESCRIPTION: &str = "Replace lines in a file.
+
+You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
+After editing, you MUST read the file again to get the new line numbers.
+
+If you want to add lines, use `add_lines` instead
+
+Example:
+
+Given a file `test.txt`:
+```
+1|Line 1
+2|Line 2
+3|Line 3
+4|Line 4
+```
+
+To replace line 2 and 3 with:
+```
+New line 2
+New line 3
+New line 4
+```
+
+Call the tool with:
+
+start_line=2,end_line=3,content=New line 2\nNew line 3\nNew line 4
+
+Then the result will be:
+```
+1|Line 1
+2|New Line 2
+3|New Line 3
+4|New Line 4
+5|Line 4
+```
+";
 #[tool(
-    description = "Replace lines in a file. You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace. After editing, you MUST read the file again to get the new line numbers. If you want to add lines, use `add_lines` instead",
+    description = REPLACE_LINES_DESCRIPTION,
     param(name = "file_name", description = "Full path of the file"),
     param(
         name = "start_line",

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -477,11 +477,15 @@ You can use this tool to do the following:
 
 ## Constraints
 
+**You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
+Line numbers start at 1 and ranges are inclusive.**
+
+After editing, you MUST read the file again to get the new line numbers.
+
+If you intend to make multiple changes to a single file, you must read -> edit -> read -> edit -> read -> edit, etc.
+
 Prefer this over writing the full file content if you only need to change a small part of the file.
 This avoids unnecessary conflicts.
-
-You MUST read the file with line numbers first to know the start and end line numbers of the block you want to replace.
-Line numbers start at 1 and ranges are inclusive.
 
 You MUST respect the exact indentation and formatting of the file you are editing. For instance, Python code breaks if not indenting correctly.
 
@@ -557,5 +561,5 @@ pub async fn edit_file(
     let write_cmd = Command::WriteFile(file_name.into(), lines.join("\n"));
     context.exec_cmd(&write_cmd).await?;
 
-    Ok(format!("Successfully replaced block in {file_name}").into())
+    Ok(format!("Successfully replaced content in {file_name}. Before making new edits, you MUST read the file again, as the line numbers WILL have changed.").into())
 }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -472,6 +472,8 @@ const REPLACE_LINES_DESCRIPTION: &str = "Replace lines in a file.
 You MUST read the file with line numbers first BEFORE EVERY EDIT, to know the start and end line numbers of the block you want to replace.
 After editing, you MUST read the file again to get the new line numbers.
 
+You MUST use the correct amount of whitespace.
+
 If you want to add lines, use `add_lines` instead
 
 Example:
@@ -513,7 +515,7 @@ Then the result will be:
     ),
     param(
         name = "end_line",
-        description = "End line number of the block to replace. Inclusive! End line will be replaced as well."
+        description = "Last line number of the block to replace."
     ),
     param(name = "content", description = "Replacement content")
 )]

--- a/src/agent/util.rs
+++ b/src/agent/util.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use anyhow::Result;
-use swiftide_core::SimplePrompt;
+use swiftide::traits::SimplePrompt;
 use uuid::Uuid;
 
 use crate::commands::Responder;

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -47,7 +47,7 @@ pub fn available_tools(
         tools::shell_command(),
         tools::search_code(),
         tools::fetch_url(),
-        tools::replace_block(),
+        tools::edit_file(),
         tools::ExplainCode::new(query_pipeline).boxed(),
     ];
 

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -285,12 +285,12 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
 
         // Tool usage
         "When writing files, ensure you write and implement everything, everytime. Do NOT leave anything out. Writing a file overwrites the entire file, so it MUST include the full, completed contents of the file. Do not make changes other than the ones requested.",
-        "Prefer using block replacements over writing files, if possible. This is faster and less error prone. You can only make ONE block replacement at the time. Otherwise you must retrieve the line numbers again.",
-        "Before replacing a block, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
-        "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately",
+        "Prefer using `edit_file` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `edit_file` call at the time. After each `edit_file` you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed..",
+        "Before every call to `edit_file`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
+        "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately. Every single edit MUST be preceded by a `read_file_with_line_numbers`",
         "If you create a pull request, you must ensure the tests pass",
         "If you just want to run the tests, prefer running the tests over running coverage, as running tests is faster",
-        "NEVER write a file before having read it",
+        "NEVER write or edit a file before having read it",
 
         // Code writing
         "When writing code or tests, make sure this is idiomatic for the language",

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -287,6 +287,7 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         // Tool usage
         "When writing files, ensure you write and implement everything, everytime. Do NOT leave anything out. Writing a file overwrites the entire file, so it MUST include the full, completed contents of the file. Do not make changes other than the ones requested.",
         "Prefer editing files with `replace_lines` and `add_lines` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `replace_lines` or `add_lines` call at the time. After each you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed.",
+        "If you are only adding NEW lines, you MUST use `add_lines`",
         "Before every call to `replace_lines` or `add_lines`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
         "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately. Every single edit MUST be preceded by a `read_file_with_line_numbers`",
         "If you create a pull request, you must ensure the tests pass",

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -287,7 +287,7 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         // Tool usage
         "When writing files, ensure you write and implement everything, everytime. Do NOT leave anything out. Writing a file overwrites the entire file, so it MUST include the full, completed contents of the file. Do not make changes other than the ones requested.",
         "Prefer editing files with `replace_lines` and `add_lines` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `replace_lines` or `add_lines` call at the time. After each you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed.",
-        "Before every call to `edit_file`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
+        "Before every call to `replace_lines` or `add_lines`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
         "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately. Every single edit MUST be preceded by a `read_file_with_line_numbers`",
         "If you create a pull request, you must ensure the tests pass",
         "If you just want to run the tests, prefer running the tests over running coverage, as running tests is faster",

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -38,7 +38,8 @@ pub fn available_tools(
     let query_pipeline = indexing::build_query_pipeline(repository)?;
 
     let mut tools = vec![
-        tools::read_file(),
+        // Only allow this agent to read with line numbers to avoid accidental guessing
+        // tools::read_file(),
         tools::read_file_with_line_numbers(),
         tools::write_file(),
         tools::search_file(),

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -287,6 +287,7 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "When writing files, ensure you write and implement everything, everytime. Do NOT leave anything out. Writing a file overwrites the entire file, so it MUST include the full, completed contents of the file. Do not make changes other than the ones requested.",
         "Prefer using `edit_file` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `edit_file` call at the time. After each `edit_file` you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed..",
         "Before every call to `edit_file`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
+        "If you want to insert content with `edit_file`, it will be added AFTER start_line. Set end_line to 0, otherwise it will replace",
         "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately. Every single edit MUST be preceded by a `read_file_with_line_numbers`",
         "If you create a pull request, you must ensure the tests pass",
         "If you just want to run the tests, prefer running the tests over running coverage, as running tests is faster",

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -47,7 +47,8 @@ pub fn available_tools(
         tools::shell_command(),
         tools::search_code(),
         tools::fetch_url(),
-        tools::edit_file(),
+        tools::replace_lines(),
+        tools::add_lines(),
         tools::ExplainCode::new(query_pipeline).boxed(),
     ];
 
@@ -285,9 +286,8 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
 
         // Tool usage
         "When writing files, ensure you write and implement everything, everytime. Do NOT leave anything out. Writing a file overwrites the entire file, so it MUST include the full, completed contents of the file. Do not make changes other than the ones requested.",
-        "Prefer using `edit_file` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `edit_file` call at the time. After each `edit_file` you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed..",
+        "Prefer editing files with `replace_lines` and `add_lines` over `write_file`, if possible. This is faster and less error prone. You can only make ONE `replace_lines` or `add_lines` call at the time. After each you MUST call `read_file_with_line_numbers` again, as the linenumbers WILL have changed.",
         "Before every call to `edit_file`, you MUST read the file content with the line numbers. You are not allowed to count lines yourself.",
-        "If you want to insert content with `edit_file`, it will be added AFTER start_line. Set end_line to 0, otherwise it will replace",
         "If you intend to edit multiple files or multiple edits in a single file, outline your plan first, then call the first tool immediately. Every single edit MUST be preceded by a `read_file_with_line_numbers`",
         "If you create a pull request, you must ensure the tests pass",
         "If you just want to run the tests, prefer running the tests over running coverage, as running tests is faster",
@@ -295,6 +295,7 @@ fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
 
         // Code writing
         "When writing code or tests, make sure this is idiomatic for the language",
+        "When writing code, make sure you account for edge cases",
         "When writing tests, verify that test coverage has changed. If it hasn't, the tests are not doing anything. This means you _must_ run coverage after creating a new test.",
         "When writing tests, make sure you cover all edge cases",
         "When writing tests, if a specific test continues to be troublesome, think out of the box and try to solve the problem in a different way, or reset and focus on other tests first",

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -83,6 +83,10 @@ pub struct Config {
     /// OpenTelemetry tracing feature toggle
     #[serde(default = "default_otel_enabled")]
     pub otel_enabled: bool,
+
+    /// How the agent will edit files, defaults to whole
+    #[serde(default)]
+    pub agent_edit_mode: AgentEditMode,
 }
 
 fn default_otel_enabled() -> bool {
@@ -108,6 +112,15 @@ pub enum SupportedToolExecutors {
     #[default]
     Docker,
     Local,
+}
+
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize, Default, strum_macros::EnumIs)]
+#[serde(rename_all = "kebab-case")]
+pub enum AgentEditMode {
+    #[default]
+    Whole,
+    Line,
+    // i.e. udiff, llm reviewed, etc
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/frontend/chat_mode/message_formatting.rs
+++ b/src/frontend/chat_mode/message_formatting.rs
@@ -185,8 +185,12 @@ fn pretty_format_tool(tool_call: &swiftide::chat_completion::ToolCall) -> Option
             "searching github for code matching `{}`",
             get_value(parsed_args, "query")?
         ),
-        "replace_block" => format!(
+        "replace_lines" => format!(
             "replacing lines in file `{}`",
+            get_value(parsed_args, "file_name")?
+        ),
+        "add_lines" => format!(
+            "adding lines to file `{}`",
             get_value(parsed_args, "file_name")?
         ),
         "read_file_with_line_numbers" => format!(

--- a/src/git/util.rs
+++ b/src/git/util.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::Result;
-use swiftide_core::{Command, ToolExecutor};
+use swiftide::{traits::Command, traits::ToolExecutor};
 
 use crate::util::accept_non_zero_exit;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,8 +2,8 @@
 #![allow(clippy::missing_panics_doc)]
 use anyhow::Result;
 use ratatui::{backend::TestBackend, Terminal};
-use swiftide::chat_completion::ChatCompletionResponse;
-use swiftide_core::{ChatCompletion, EmbeddingModel, Persist as _, SimplePrompt};
+use swiftide::chat_completion::{ChatCompletion, ChatCompletionResponse};
+use swiftide::traits::{EmbeddingModel, Persist as _, SimplePrompt};
 use tokio_util::task::AbortOnDropHandle;
 use uuid::Uuid;
 

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -118,7 +118,7 @@ async fn test_edit_file() {
     let new_file_content = std::fs::read_to_string(tempdir.path().join("test.txt")).unwrap();
 
     assert_eq!(new_file_content, "line1\none line\nline5");
-    assert!(tool_response.contains("Successfully replaced block"));
+    assert!(tool_response.contains("Successfully replaced content"));
 
     std::fs::write(
         tempdir.path().join("test.txt"),
@@ -137,7 +137,7 @@ async fn test_edit_file() {
         })
     );
 
-    assert!(tool_response.contains("Successfully replaced block"));
+    assert!(tool_response.contains("Successfully replaced content"));
     assert_eq!(
         std::fs::read_to_string(tempdir.path().join("test.txt")).unwrap(),
         "line1\none\nline\nline5"
@@ -187,6 +187,7 @@ async fn test_edit_file() {
     .unwrap();
 
     // Appending a block with end_line zero
+    // NOTE: Current state of LLMs uses a different tool when line editing
     let tool_response = invoke!(
         &tool,
         &context,
@@ -198,12 +199,7 @@ async fn test_edit_file() {
         })
     );
 
-    assert!(
-        tool_response.contains("Successfully replaced block"),
-        "{}",
-        &tool_response
-    );
-
+    assert!(tool_response.contains("Successfully replaced content"));
     assert_eq!(
         std::fs::read_to_string(tempdir.path().join("test-add.txt")).unwrap(),
         "line1\nline2\nadded\nblock\nline3\nline4\nline5"

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -85,8 +85,8 @@ async fn test_search_code() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_replace_block() {
-    let tool = tools::replace_block();
+async fn test_edit_file() {
+    let tool = tools::edit_file();
     let context = setup_context();
 
     let tempdir = tempdir().unwrap();
@@ -103,7 +103,7 @@ async fn test_replace_block() {
             "file_name": tempdir.path().join("test.txt").to_str().unwrap(),
             "start_line": "2",
             "end_line": "4",
-            "replacement": "one line"
+            "content": "one line"
         })
     );
 
@@ -125,7 +125,7 @@ async fn test_replace_block() {
             "file_name": tempdir.path().join("test.txt").to_str().unwrap(),
             "start_line": "2",
             "end_line": "4",
-            "replacement": "one\nline"
+            "content": "one\nline"
         })
     );
 
@@ -142,7 +142,7 @@ async fn test_replace_block() {
             "file_name": tempdir.path().join("test.txt").to_str().unwrap(),
             "start_line": "2",
             "end_line": "10",
-            "replacement": "one\nline"
+            "content": "one\nline"
         })
     );
 
@@ -156,7 +156,7 @@ async fn test_replace_block() {
         "file_name": tempdir.path().join("test2.txt").to_str().unwrap(),
         "start_line": "2",
         "end_line": "4",
-        "replacement": "one\nline"
+        "content": "one\nline"
     });
 
     let tool_response = tool
@@ -186,7 +186,7 @@ async fn test_replace_block() {
             "file_name": tempdir.path().join("test-add.txt").to_str().unwrap(),
             "start_line": "2",
             "end_line": "0",
-            "replacement": "added\nblock"
+            "content": "added\nblock"
         })
     );
 
@@ -198,7 +198,7 @@ async fn test_replace_block() {
 
     assert_eq!(
         std::fs::read_to_string(tempdir.path().join("test-add.txt")).unwrap(),
-        "line1\nadded\nblock\nline2\nline3\nline4\nline5"
+        "line1\nline2\nadded\nblock\nline3\nline4\nline5"
     );
 }
 
@@ -222,7 +222,7 @@ async fn test_read_file_with_line_numbers() {
         })
     );
 
-    let expected = "1: line1\n2: line2\n3: line3\n4: line4\n5: line5";
+    let expected = "1|line1\n2|line2\n3|line3\n4|line4\n5|line5";
     assert_eq!(file_content, expected);
 }
 

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -86,7 +86,7 @@ async fn test_search_code() {
 
 #[test_log::test(tokio::test)]
 async fn test_edit_file() {
-    let tool = tools::edit_file();
+    let tool = tools::replace_lines();
     let context = setup_context();
 
     let tempdir = tempdir().unwrap();


### PR DESCRIPTION
This PR improves line editing, and makes it opt-in. Different kinds of edits work best for different kind of llms (and optimizations here are probably void in a couple of weeks anyway).

- Format line numbers as `1|<line>`. Python needs white space correctly indented.
- Disable regular file reading. With line numbers ONLY.
- Nudge LLM to use write file for new files.
- Append instead of prepend, more intuitive and enables appending to end of file as well.
- Renamed replace block to edit file
- More elaborate prompt on how the edit file works
