### PR TITLE
feat: Simplify docker with new executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,32 +1125,20 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
 dependencies = [
- "async-stream",
  "base64 0.22.1",
- "bitflags 2.8.0",
- "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
- "chrono",
  "futures-core",
  "futures-util",
  "hex",
- "home",
  "http 1.2.0",
  "http-body-util",
  "hyper 1.6.0",
  "hyper-named-pipe",
- "hyper-rustls 0.27.5",
  "hyper-util",
  "hyperlocal",
  "log",
- "num",
  "pin-project-lite",
- "rand",
- "rustls 0.23.22",
- "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1158,24 +1146,10 @@ dependencies = [
  "serde_urlencoded",
  "thiserror 2.0.11",
  "tokio",
- "tokio-stream",
  "tokio-util",
- "tonic",
  "tower-service",
  "url",
  "winapi",
-]
-
-[[package]]
-name = "bollard-buildkit-proto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4565dfbe8ac1deb443211d55a1985cc33fd9d3606cf86377edbb538682993f30"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
- "ureq",
 ]
 
 [[package]]
@@ -1184,11 +1158,6 @@ version = "1.47.1-rc.27.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
 dependencies = [
- "base64 0.22.1",
- "bollard-buildkit-proto",
- "bytes",
- "chrono",
- "prost",
  "serde",
  "serde_repr",
  "serde_with",
@@ -3165,15 +3134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7457,20 +7417,26 @@ dependencies = [
 
 [[package]]
 name = "swiftide-docker-executor"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071307b3a3a37425fdadd06f995d38f0dc23a4e3fcb618e8c4ce63cef9f7f619"
+checksum = "afe1dc621e881bf4d2ece220a3cc11d7b3dcb126788fd3fbbdfb118d7c32413e"
 dependencies = [
  "anyhow",
  "async-trait",
  "bollard",
  "dirs 6.0.0",
+ "flate2",
+ "http-body-util",
  "ignore",
  "indoc",
+ "prost",
  "swiftide-core",
+ "tempfile",
  "thiserror 2.0.11",
  "tokio",
  "tokio-tar",
+ "tonic",
+ "tonic-build",
  "tracing",
  "uuid",
  "walkdir",
@@ -8280,6 +8246,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["rt"] }
 strum = "0.26.3"
 strum_macros = "0.26.4"
-swiftide-docker-executor = "0.4.2"
+swiftide-docker-executor = "0.5.0"
 swiftide = { version = "0.18.0", features = [
   "lancedb",
   "openai",

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,25 +3,24 @@ ARG RUST_VERSION=1.83-slim
 FROM rust:${RUST_VERSION} as builder
 
 RUN rustup component add clippy rustfmt
-RUN rustup toolchain install nightly
 
-# Install tool dependencies for app and git/ssh for the workspace
+RUN cargo install cargo-llvm-cov
+
+# These are needed for kwaak itself to compile and run
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  ripgrep fd-find git ssh curl  \
+  ssh curl  \
   libstdc++6 \
   build-essential \
   protobuf-compiler \
   libprotobuf-dev \
   pkg-config libssl-dev iputils-ping \
   make \
-
   # Needed for copypasta (internal for kwaak)
   libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
-  && rm -rf /var/lib/apt/lists/* \
-  && cp /usr/bin/fdfind /usr/bin/fd
-
-RUN cargo install cargo-nextest
-RUN cargo +nightly install cargo-llvm-cov cargo-nextest
+  # These are needed for kwaak to operate on itself
+  git \
+  # Then clean up
+  && rm -rf /var/lib/apt/lists/*
 
 COPY . /app
 

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,7 +1,7 @@
 # A lightweight image used for tests
-FROM alpine:latest
+FROM ubuntu:latest
 
-RUN apk add git fd ripgrep
+RUN apt-get update && apt install git -y --no-install-recommends
 
 COPY . /app
 

--- a/README.md
+++ b/README.md
@@ -123,22 +123,34 @@ Powered by [Swiftide](https://github.com/bosun-ai/swiftide)
 
 Before you can run Kwaak, make sure you have Docker installed on your machine.
 
+#### Docker
+
 Kwaak expects a Dockerfile in the root of your project. If you already have a Dockerfile, you can just name it differently and configure it in the configuration file. This Dockerfile should contain all the dependencies required to test and run your code.
 
 > [!NOTE]
 > Docker is used to provide a safe execution environment for the agents. It does not affect the performance of the LLMs. The LLMs are running either locally or in the cloud, and the docker container is only used to run the code. This is done to ensure that the agents cannot access your local system. Kwaak itself runs locally.
 
-Additionally, it expects the following to be present:
+Additionally, the Dockerfile expects `git` and should be `ubuntu` based.
 
-- **git**: Required for git operations
-- **fd** [github](https://github.com/sharkdp/fd): Required for searching files. Note that it should be available as `fd`, some systems have it as `fdfind`.
-- **ripgrep** [github](https://github.com/BurntSushi/ripgrep): Required for searching _in_ files. Note that it should be available as `rg`.
+A simple example for Rust:
+
+```Dockerfile
+FROM rust:latest
+
+RUN apt-get update && apt install git -y --no-install-recommends
+
+COPY . /app
+
+WORKDIR /app
+```
 
 If you already have a Dockerfile for other purposes, you can either extend it or provide a new one and override the dockerfile path in the configuration.
 
 _For an example Dockerfile in Rust, see [this project's Dockerfile](/Dockerfile)_
 
-Additionally, you will need an OpenAI API key (if OpenAI is your LLM provider).
+#### Api keys
+
+Additionally, you will need an API key for your LLM of choice.
 
 If you'd like kwaak to be able to make pull requests, search github code, and automatically push to a remote, a [github token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 

--- a/kwaak.toml
+++ b/kwaak.toml
@@ -8,8 +8,8 @@ tool_executor = "docker"
 otel_enabled = true
 
 [commands]
-test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo nextest run --no-fail-fast --color=never"
-coverage = "cargo +nightly llvm-cov nextest --no-clean --summary-only"
+test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo test --no-fail-fast --color=never"
+coverage = "cargo llvm-cov nextest --no-clean --summary-only"
 # lint_and_fix = "cargo clippy --fix --allow-dirty --allow-staged; cargo fmt"
 
 [git]


### PR DESCRIPTION
Uses the new executor. Instead of relying on direct shell execution, it uses grpc. The client is copied in with 2 other deps (rg/fd) when building the image. It makes the whole experience a lot smoother.

Additionally, a host of errors and inconsistencies were fixed.

Fixes #251 and #250 
