### PR TITLE
feat: Improve rate and context limit handling for OpenAI and OpenRouter with configurable backoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3850,6 +3850,7 @@ dependencies = [
  "async-anthropic",
  "async-openai",
  "async-trait",
+ "backoff",
  "clap",
  "config",
  "copypasta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ num_cpus = "1.16.0"
 htmd = "0.1.6"
 ansi-to-tui = "7.0.0"
 tempfile = { version = "3.16.0" }
+backoff = "0.4.0"
 
 copypasta = "0.10.1"
 strip-ansi-escapes = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -296,6 +296,29 @@ You can mix and match models from different providers for different tasks.
 
 #### Other configuration
 
+#### Backoff Configuration
+
+Kwaak uses an `ExponentialBackoffBuilder` to handle retry strategies. You can configure the backoff settings in the `kwaak.toml` file under the `[backoff]` section. 
+These settings are optional, and default to the following values:
+
+- `initial_interval`: Defaults to 15 seconds. This sets the initial waiting time between retries.
+- `multiplier`: Defaults to 2.0. This factor multiplies the interval on each retry attempt.
+- `randomization_factor`: Defaults to 0.05. Introduces randomness to avoid retry storms.
+- `max_elapsed_time`: Defaults to 120 seconds. This total time all attempts are allowed.
+
+Example Configuration:
+
+```toml
+[backoff]
+initial_interval = "10s"
+multiplier = 1.5
+randomization_factor = 0.1
+max_elapsed_time = "100s"
+```
+
+Adjust these values based on your specific requirements and preferences.
+
+
 - **`agent_custom_constraints`**: Additional constraints / instructions for the agent.
   These are passes to the agent in the system prompt and are rendered in a list. If you
   intend to use more complicated instructions, consider adding a file to read in the

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ You can mix and match models from different providers for different tasks.
 
 #### Backoff Configuration
 
-Kwaak uses the exponential backoff strategy to handle retries. Currently only
-OpenAI calls will make use of the backoff parameters. You can configure the
+Kwaak uses the exponential backoff strategy to handle retries. Currently, only
+OpenAI and OpenRouter calls will make use of the backoff parameters. You can configure the
 backoff settings in the `kwaak.toml` file under a `[backoff]` section. These
 settings are optional, and default to the following values:
 

--- a/README.md
+++ b/README.md
@@ -294,30 +294,30 @@ For both you can provide a `base_url` to use a custom API endpoint.
 
 You can mix and match models from different providers for different tasks.
 
-#### Other configuration
-
 #### Backoff Configuration
 
-Kwaak uses an `ExponentialBackoffBuilder` to handle retry strategies. You can configure the backoff settings in the `kwaak.toml` file under the `[backoff]` section. 
-These settings are optional, and default to the following values:
+Kwaak uses the exponential backoff strategy to handle retries. Currently only
+OpenAI calls will make use of the backoff parameters. You can configure the
+backoff settings in the `kwaak.toml` file under a `[backoff]` section. These
+settings are optional, and default to the following values:
 
-- `initial_interval`: Defaults to 15 seconds. This sets the initial waiting time between retries.
+
+- `initial_interval_sec`: Defaults to 15 seconds. This sets the initial waiting time between retries.
 - `multiplier`: Defaults to 2.0. This factor multiplies the interval on each retry attempt.
 - `randomization_factor`: Defaults to 0.05. Introduces randomness to avoid retry storms.
-- `max_elapsed_time`: Defaults to 120 seconds. This total time all attempts are allowed.
+- `max_elapsed_time_sec`: Defaults to 120 seconds. This total time all attempts are allowed.
 
 Example Configuration:
 
 ```toml
 [backoff]
-initial_interval = "10s"
-multiplier = 1.5
-randomization_factor = 0.1
-max_elapsed_time = "100s"
+initial_interval_sec = "15"
+multiplier = 2.0
+randomization_factor = 0.05
+max_elapsed_time_sec = "120"
 ```
 
-Adjust these values based on your specific requirements and preferences.
-
+#### Other configuration
 
 - **`agent_custom_constraints`**: Additional constraints / instructions for the agent.
   These are passes to the agent in the system prompt and are rendered in a list. If you

--- a/src/agent/v1.rs
+++ b/src/agent/v1.rs
@@ -125,10 +125,15 @@ pub async fn start(
     repository: &Repository,
     command_responder: Arc<dyn Responder>,
 ) -> Result<RunningAgent> {
-    let query_provider: Box<dyn ChatCompletion> =
-        repository.config().query_provider().try_into()?;
-    let fast_query_provider: Box<dyn SimplePrompt> =
-        repository.config().indexing_provider().try_into()?;
+    let backoff = repository.config().backoff;
+    let query_provider: Box<dyn ChatCompletion> = repository
+        .config()
+        .query_provider()
+        .get_chat_completion_model(backoff)?;
+    let fast_query_provider: Box<dyn SimplePrompt> = repository
+        .config()
+        .indexing_provider()
+        .get_simple_prompt_model(backoff)?;
 
     let github_session = match repository.config().github_api_key {
         Some(_) => Some(Arc::new(GithubSession::from_repository(&repository)?)),

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -171,7 +171,7 @@ impl Default for DockerConfiguration {
 }
 
 /// Backoff configuration for api calls.
-/// Each time an api call fails backoff will wait an increasing period of time for each subsiquent
+/// Each time an api call fails backoff will wait an increasing period of time for each subsequent
 /// retry attempt. see <https://docs.rs/backoff/latest/backoff/> for more details.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct BackoffConfiguration {

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -44,6 +44,9 @@ pub struct Config {
     #[serde(default)]
     pub docker: DockerConfiguration,
 
+    #[serde(default)]
+    pub backoff: BackoffConfiguration,
+
     pub git: GitConfiguration,
 
     /// Optional: Use tavily as a search tool
@@ -161,6 +164,25 @@ impl Default for DockerConfiguration {
         Self {
             dockerfile: "Dockerfile".into(),
             context: ".".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct BackoffConfiguration {
+    pub initial_interval_sec: u64,
+    pub multiplier: f64,
+    pub randomization_factor: f64,
+    pub max_elapsed_time_sec: u64,
+}
+
+impl Default for BackoffConfiguration {
+    fn default() -> Self {
+        Self {
+            initial_interval_sec: 15,
+            multiplier: 2.0,
+            randomization_factor: 0.05,
+            max_elapsed_time_sec: 120,
         }
     }
 }

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -44,6 +44,8 @@ pub struct Config {
     #[serde(default)]
     pub docker: DockerConfiguration,
 
+    /// Optional: Backoff configuration for api calls
+    /// this is currently only used for open-ai and open-router
     #[serde(default)]
     pub backoff: BackoffConfiguration,
 
@@ -168,11 +170,19 @@ impl Default for DockerConfiguration {
     }
 }
 
+/// Backoff configuration for api calls.
+/// Each time an api call fails backoff will wait an increasing period of time for each subsiquent
+/// retry attempt. see <https://docs.rs/backoff/latest/backoff/> for more details.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct BackoffConfiguration {
+    /// Initial interval in seconds between retries
     pub initial_interval_sec: u64,
+    /// The factor by which the interval is multiplied on each retry attempt
     pub multiplier: f64,
+    /// Introduces randomness to avoid retry storms
     pub randomization_factor: f64,
+    /// Total time all attempts are allowed in seconds. Once a retry must wait longer than this,
+    /// the request is considered to have failed.
     pub max_elapsed_time_sec: u64,
 }
 

--- a/src/config/llm_configuration.rs
+++ b/src/config/llm_configuration.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 #[cfg(debug_assertions)]
-use crate::{config::Config, test_utils::NoopLLM};
+use crate::{config::BackoffConfiguration, test_utils::NoopLLM};
 
 use super::ApiKey;
 use anyhow::{Context as _, Result};
@@ -218,37 +218,6 @@ pub struct EmbeddingModelWithSize {
     pub vector_size: i32,
 }
 
-impl LLMConfiguration {
-    pub(crate) fn vector_size(&self) -> i32 {
-        match self {
-            LLMConfiguration::OpenAI {
-                embedding_model, ..
-            } => match embedding_model {
-                OpenAIEmbeddingModel::TextEmbedding3Small => 1536,
-                OpenAIEmbeddingModel::TextEmbedding3Large => 3072,
-            },
-            LLMConfiguration::Ollama {
-                embedding_model, ..
-            } => {
-                embedding_model
-                    .as_ref()
-                    .expect("Expected an embedding model for ollama")
-                    .vector_size
-            }
-            LLMConfiguration::OpenRouter { .. } => {
-                panic!("OpenRouter does not have an embedding model")
-            }
-            LLMConfiguration::FastEmbed { embedding_model } => embedding_model.vector_size(),
-
-            #[cfg(debug_assertions)]
-            LLMConfiguration::Testing => 1,
-            LLMConfiguration::Anthropic { .. } => {
-                panic!("Anthropic does not have an embedding model")
-            }
-        }
-    }
-}
-
 #[derive(
     Debug,
     Clone,
@@ -291,141 +260,165 @@ pub enum OpenAIEmbeddingModel {
     TextEmbedding3Large,
 }
 
-fn build_openai(
-    api_key: Option<&ApiKey>,
-    embedding_model: &OpenAIEmbeddingModel,
-    prompt_model: &OpenAIPromptModel,
-    base_url: Option<&Url>,
-) -> Result<integrations::openai::OpenAI> {
-    let api_key = api_key.context("Expected an api key")?;
-
-    let mut config =
-        async_openai::config::OpenAIConfig::default().with_api_key(api_key.expose_secret());
-
-    if let Some(base_url) = base_url {
-        config = config.with_api_base(base_url.to_string());
-    };
-
-    // Load backoff settings from configuration
-    let initial_interval = Duration::from_secs(
-        Config::get("backoff.initial_interval").unwrap_or(Duration::from_secs(15)),
-    );
-    let multiplier = Config::get("backoff.multiplier").unwrap_or(2.0);
-    let randomization_factor = Config::get("backoff.randomization_factor").unwrap_or(0.05);
-    let max_elapsed_time = Duration::from_secs(
-        Config::get("backoff.max_elapsed_time").unwrap_or(Duration::from_secs(120)),
-    );
-
-    let backoff = ExponentialBackoffBuilder::default()
-        .with_initial_interval(initial_interval)
-        .with_multiplier(multiplier)
-        .with_randomization_factor(randomization_factor)
-        .with_max_elapsed_time(Some(max_elapsed_time))
-        .build();
-
-    let client = async_openai::Client::with_config(config).with_backoff(backoff);
-
-    integrations::openai::OpenAI::builder()
-        .client(client)
-        .default_prompt_model(prompt_model.to_string())
-        .default_embed_model(embedding_model.to_string())
-        .build()
-        .context("Failed to build OpenAI client")
-}
-
-fn build_ollama(llm_config: &LLMConfiguration) -> Result<Ollama> {
-    let LLMConfiguration::Ollama {
-        prompt_model,
-        embedding_model,
-        base_url,
-        ..
-    } = llm_config
-    else {
-        anyhow::bail!("Expected Ollama configuration")
-    };
-
-    let mut config = OllamaConfig::default();
-
-    if let Some(base_url) = base_url {
-        config.with_api_base(base_url.as_str());
-    };
-
-    let mut builder = Ollama::builder()
-        .client(async_openai::Client::with_config(config))
-        .to_owned();
-
-    if let Some(embedding_model) = embedding_model {
-        builder.default_embed_model(embedding_model.name.clone());
-    }
-
-    if let Some(prompt_model) = prompt_model {
-        builder.default_prompt_model(prompt_model);
-    }
-
-    builder.build().context("Failed to build Ollama client")
-}
-
-fn build_anthropic(llm_config: &LLMConfiguration) -> Result<Anthropic> {
-    let LLMConfiguration::Anthropic {
-        api_key,
-        prompt_model,
-    } = llm_config
-    else {
-        anyhow::bail!("Expected Anthropic configuration")
-    };
-
-    let api_key = api_key.as_ref().context("Expected an api key")?;
-    let client = async_anthropic::Client::from_api_key(api_key);
-
-    Anthropic::builder()
-        .client(client)
-        .default_prompt_model(prompt_model.to_string())
-        .build()
-        .context("Failed to build Anthropic client")
-}
-
-fn build_open_router(llm_config: &LLMConfiguration) -> Result<OpenRouter> {
-    let LLMConfiguration::OpenRouter {
-        prompt_model,
-        api_key,
-    } = llm_config
-    else {
-        anyhow::bail!("Expected OpenRouter configuration")
-    };
-
-    let api_key = api_key.as_ref().context("Expected an api key")?;
-    let config = OpenRouterConfig::builder()
-        .api_key(api_key)
-        .site_url("https://github.com/bosun-ai/kwaak")
-        .site_name("Kwaak")
-        .build()?;
-
-    OpenRouter::builder()
-        .client(async_openai::Client::with_config(config))
-        .default_prompt_model(prompt_model)
-        .to_owned()
-        .build()
-        .context("Failed to build OpenRouter client")
-}
-
-impl TryInto<Box<dyn EmbeddingModel>> for &LLMConfiguration {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> std::result::Result<Box<dyn EmbeddingModel>, Self::Error> {
-        let boxed = match self {
+impl LLMConfiguration {
+    pub(crate) fn vector_size(&self) -> i32 {
+        match self {
             LLMConfiguration::OpenAI {
-                api_key,
-                embedding_model,
-                prompt_model,
-                base_url,
-            } => Box::new(build_openai(
-                api_key.as_ref(),
-                embedding_model,
-                prompt_model,
-                base_url.as_ref(),
-            )?) as Box<dyn EmbeddingModel>,
+                embedding_model, ..
+            } => match embedding_model {
+                OpenAIEmbeddingModel::TextEmbedding3Small => 1536,
+                OpenAIEmbeddingModel::TextEmbedding3Large => 3072,
+            },
+            LLMConfiguration::Ollama {
+                embedding_model, ..
+            } => {
+                embedding_model
+                    .as_ref()
+                    .expect("Expected an embedding model for ollama")
+                    .vector_size
+            }
+            LLMConfiguration::OpenRouter { .. } => {
+                panic!("OpenRouter does not have an embedding model")
+            }
+            LLMConfiguration::FastEmbed { embedding_model } => embedding_model.vector_size(),
+
+            #[cfg(debug_assertions)]
+            LLMConfiguration::Testing => 1,
+            LLMConfiguration::Anthropic { .. } => {
+                panic!("Anthropic does not have an embedding model")
+            }
+        }
+    }
+
+    fn build_openai(
+        &self,
+        backoff_config: BackoffConfiguration,
+    ) -> Result<integrations::openai::OpenAI> {
+        let LLMConfiguration::OpenAI {
+            api_key,
+            embedding_model,
+            prompt_model,
+            base_url,
+        } = self
+        else {
+            anyhow::bail!("Expected Ollama configuration")
+        };
+
+        let api_key = api_key.as_ref().context("Expected an api key")?;
+
+        let mut config =
+            async_openai::config::OpenAIConfig::default().with_api_key(api_key.expose_secret());
+
+        if let Some(base_url) = base_url {
+            config = config.with_api_base(base_url.to_string());
+        };
+
+        // Load backoff settings from configuration
+        //let c_backoff = config.backoff;
+        let backoff = ExponentialBackoffBuilder::default()
+            .with_initial_interval(Duration::from_secs(backoff_config.initial_interval_sec))
+            .with_multiplier(backoff_config.multiplier)
+            .with_randomization_factor(backoff_config.randomization_factor)
+            .with_max_elapsed_time(Some(Duration::from_secs(
+                backoff_config.max_elapsed_time_sec,
+            )))
+            .build();
+
+        let client = async_openai::Client::with_config(config).with_backoff(backoff);
+
+        integrations::openai::OpenAI::builder()
+            .client(client)
+            .default_prompt_model(prompt_model.to_string())
+            .default_embed_model(embedding_model.to_string())
+            .build()
+            .context("Failed to build OpenAI client")
+    }
+
+    fn build_ollama(&self) -> Result<Ollama> {
+        let LLMConfiguration::Ollama {
+            prompt_model,
+            embedding_model,
+            base_url,
+            ..
+        } = self
+        else {
+            anyhow::bail!("Expected Ollama configuration")
+        };
+
+        let mut config = OllamaConfig::default();
+
+        if let Some(base_url) = base_url {
+            config.with_api_base(base_url.as_str());
+        };
+
+        let mut builder = Ollama::builder()
+            .client(async_openai::Client::with_config(config))
+            .to_owned();
+
+        if let Some(embedding_model) = embedding_model {
+            builder.default_embed_model(embedding_model.name.clone());
+        }
+
+        if let Some(prompt_model) = prompt_model {
+            builder.default_prompt_model(prompt_model);
+        }
+
+        builder.build().context("Failed to build Ollama client")
+    }
+
+    fn build_anthropic(&self) -> Result<Anthropic> {
+        let LLMConfiguration::Anthropic {
+            api_key,
+            prompt_model,
+        } = self
+        else {
+            anyhow::bail!("Expected Anthropic configuration")
+        };
+
+        let api_key = api_key.as_ref().context("Expected an api key")?;
+        let client = async_anthropic::Client::from_api_key(api_key);
+
+        Anthropic::builder()
+            .client(client)
+            .default_prompt_model(prompt_model.to_string())
+            .build()
+            .context("Failed to build Anthropic client")
+    }
+
+    fn build_open_router(&self) -> Result<OpenRouter> {
+        let LLMConfiguration::OpenRouter {
+            prompt_model,
+            api_key,
+        } = self
+        else {
+            anyhow::bail!("Expected OpenRouter configuration")
+        };
+
+        let api_key = api_key.as_ref().context("Expected an api key")?;
+        let config = OpenRouterConfig::builder()
+            .api_key(api_key)
+            .site_url("https://github.com/bosun-ai/kwaak")
+            .site_name("Kwaak")
+            .build()?;
+
+        OpenRouter::builder()
+            .client(async_openai::Client::with_config(config))
+            .default_prompt_model(prompt_model)
+            .to_owned()
+            .build()
+            .context("Failed to build OpenRouter client")
+    }
+
+    pub fn get_embedding_model(
+        &self,
+        backoff_config: BackoffConfiguration,
+    ) -> Result<Box<dyn EmbeddingModel>> {
+        let boxed = match self {
+            LLMConfiguration::OpenAI { .. } => {
+                Box::new(self.build_openai(backoff_config)?) as Box<dyn EmbeddingModel>
+            }
             LLMConfiguration::Ollama { .. } => {
-                Box::new(build_ollama(self)?) as Box<dyn EmbeddingModel>
+                Box::new(self.build_ollama()?) as Box<dyn EmbeddingModel>
             }
             LLMConfiguration::OpenRouter { .. } => {
                 anyhow::bail!("OpenRouter does not have an embedding model")
@@ -440,80 +433,62 @@ impl TryInto<Box<dyn EmbeddingModel>> for &LLMConfiguration {
             LLMConfiguration::Anthropic { .. } => {
                 anyhow::bail!("Anthropic does not have an embedding model")
             }
+
             #[cfg(debug_assertions)]
             LLMConfiguration::Testing => Box::new(NoopLLM) as Box<dyn EmbeddingModel>,
         };
-
         Ok(boxed)
     }
-}
 
-impl TryInto<Box<dyn SimplePrompt>> for &LLMConfiguration {
-    type Error = anyhow::Error;
-    fn try_into(self) -> std::result::Result<Box<dyn SimplePrompt>, Self::Error> {
+    pub fn get_simple_prompt_model(
+        &self,
+        backoff_config: BackoffConfiguration,
+    ) -> Result<Box<dyn SimplePrompt>> {
         let boxed = match self {
-            LLMConfiguration::OpenAI {
-                api_key,
-                embedding_model,
-                prompt_model,
-                base_url,
-            } => Box::new(build_openai(
-                api_key.as_ref(),
-                embedding_model,
-                prompt_model,
-                base_url.as_ref(),
-            )?) as Box<dyn SimplePrompt>,
+            LLMConfiguration::OpenAI { .. } => {
+                Box::new(self.build_openai(backoff_config)?) as Box<dyn SimplePrompt>
+            }
             LLMConfiguration::Ollama { .. } => {
-                Box::new(build_ollama(self)?) as Box<dyn SimplePrompt>
+                Box::new(self.build_ollama()?) as Box<dyn SimplePrompt>
             }
             LLMConfiguration::OpenRouter { .. } => {
-                Box::new(build_open_router(self)?) as Box<dyn SimplePrompt>
+                Box::new(self.build_open_router()?) as Box<dyn SimplePrompt>
             }
             LLMConfiguration::FastEmbed { .. } => {
-                anyhow::bail!("FastEmbed does not have a prompt model")
+                anyhow::bail!("FastEmbed does not have a simpl prompt model")
             }
             LLMConfiguration::Anthropic { .. } => {
-                Box::new(build_anthropic(self)?) as Box<dyn SimplePrompt>
+                Box::new(self.build_anthropic()?) as Box<dyn SimplePrompt>
             }
             #[cfg(debug_assertions)]
             LLMConfiguration::Testing => Box::new(NoopLLM) as Box<dyn SimplePrompt>,
         };
-
         Ok(boxed)
     }
-}
 
-impl TryInto<Box<dyn ChatCompletion>> for &LLMConfiguration {
-    type Error = anyhow::Error;
-    fn try_into(self) -> std::result::Result<Box<dyn ChatCompletion>, Self::Error> {
+    pub fn get_chat_completion_model(
+        &self,
+        backoff_config: BackoffConfiguration,
+    ) -> Result<Box<dyn ChatCompletion>> {
         let boxed = match self {
-            LLMConfiguration::OpenAI {
-                api_key,
-                embedding_model,
-                prompt_model,
-                base_url,
-            } => Box::new(build_openai(
-                api_key.as_ref(),
-                embedding_model,
-                prompt_model,
-                base_url.as_ref(),
-            )?) as Box<dyn ChatCompletion>,
+            LLMConfiguration::OpenAI { .. } => {
+                Box::new(self.build_openai(backoff_config)?) as Box<dyn ChatCompletion>
+            }
             LLMConfiguration::Ollama { .. } => {
-                Box::new(build_ollama(self)?) as Box<dyn ChatCompletion>
+                Box::new(self.build_ollama()?) as Box<dyn ChatCompletion>
             }
             LLMConfiguration::OpenRouter { .. } => {
-                Box::new(build_open_router(self)?) as Box<dyn ChatCompletion>
+                Box::new(self.build_open_router()?) as Box<dyn ChatCompletion>
             }
             LLMConfiguration::FastEmbed { .. } => {
-                anyhow::bail!("FastEmbed does not have a prompt model")
+                anyhow::bail!("FastEmbed does not have a chat completion model")
             }
             LLMConfiguration::Anthropic { .. } => {
-                Box::new(build_anthropic(self)?) as Box<dyn ChatCompletion>
+                Box::new(self.build_anthropic()?) as Box<dyn ChatCompletion>
             }
             #[cfg(debug_assertions)]
             LLMConfiguration::Testing => Box::new(NoopLLM) as Box<dyn ChatCompletion>,
         };
-
         Ok(boxed)
     }
 }

--- a/src/config/llm_configuration.rs
+++ b/src/config/llm_configuration.rs
@@ -1,9 +1,10 @@
 use std::{str::FromStr, time::Duration};
 
 #[cfg(debug_assertions)]
-use crate::{config::BackoffConfiguration, test_utils::NoopLLM};
+use crate::test_utils::NoopLLM;
 
 use super::ApiKey;
+use crate::config::BackoffConfiguration;
 use anyhow::{Context as _, Result};
 use backoff::ExponentialBackoffBuilder;
 use fastembed::{InitOptions, TextEmbedding};

--- a/src/evaluations/tool_evaluation_agent.rs
+++ b/src/evaluations/tool_evaluation_agent.rs
@@ -17,8 +17,13 @@ pub async fn start_tool_evaluation_agent(
     let system_prompt = v1::build_system_prompt(repository)?;
     let agent_context: Arc<dyn AgentContext> = Arc::new(DefaultContext::default());
     let executor = Arc::new(swiftide::agents::tools::local_executor::LocalExecutor::default());
-    let query_provider: Box<dyn ChatCompletion> =
-        repository.config().query_provider().try_into()?;
+
+    let backoff = repository.config().backoff;
+
+    let query_provider: Box<dyn ChatCompletion> = repository
+        .config()
+        .query_provider()
+        .get_chat_completion_model(backoff)?;
 
     let responder_for_messages = responder.clone();
     let responder_for_tools = responder.clone();

--- a/src/indexing/query.rs
+++ b/src/indexing/query.rs
@@ -30,9 +30,15 @@ pub async fn query(repository: &Repository, query: impl AsRef<str>) -> Result<St
 pub fn build_query_pipeline<'b>(
     repository: &Repository,
 ) -> Result<query::Pipeline<'b, SimilaritySingleEmbedding, states::Answered>> {
-    let query_provider: Box<dyn SimplePrompt> = repository.config().query_provider().try_into()?;
-    let embedding_provider: Box<dyn EmbeddingModel> =
-        repository.config().embedding_provider().try_into()?;
+    let backoff = repository.config().backoff;
+    let query_provider: Box<dyn SimplePrompt> = repository
+        .config()
+        .query_provider()
+        .get_simple_prompt_model(backoff)?;
+    let embedding_provider: Box<dyn EmbeddingModel> = repository
+        .config()
+        .embedding_provider()
+        .get_embedding_model(backoff)?;
 
     let lancedb =
         storage::get_lancedb(repository) as Arc<dyn Retrieve<SimilaritySingleEmbedding<()>>>;

--- a/src/indexing/repository.rs
+++ b/src/indexing/repository.rs
@@ -37,10 +37,16 @@ pub async fn index_repository(
 
     let loader = loaders::FileLoader::new(repository.path()).with_extensions(&extensions);
 
-    let indexing_provider: Box<dyn SimplePrompt> =
-        repository.config().indexing_provider().try_into()?;
-    let embedding_provider: Box<dyn EmbeddingModel> =
-        repository.config().embedding_provider().try_into()?;
+    let backoff = repository.config().backoff;
+
+    let indexing_provider: Box<dyn SimplePrompt> = repository
+        .config()
+        .indexing_provider()
+        .get_simple_prompt_model(backoff)?;
+    let embedding_provider: Box<dyn EmbeddingModel> = repository
+        .config()
+        .embedding_provider()
+        .get_embedding_model(backoff)?;
 
     let lancedb = storage::get_lancedb(repository);
     let redb = storage::get_redb(repository) as Arc<dyn NodeCache>;


### PR DESCRIPTION
Added backoff functionality for open-ai/open-router llm calls. Also did some minor refactoring to allow for this feature. 
doesn't close, but related to https://github.com/bosun-ai/kwaak/issues/296