### PR TITLE
fix: Do not include system prompt when summarizing and skip summary if agent stopped

### DIFF
--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -58,7 +58,7 @@ impl ConversationSummarizer {
                 .num_completions_since_summary
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-            if current_count < self.num_completions_for_summary {
+            if current_count < self.num_completions_for_summary || agent.is_stopped() {
                 tracing::debug!(current_count, "Not enough completions for summary");
 
                 return Box::pin(async move { Ok(()) });

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -191,13 +191,14 @@ impl ConversationSummarizer {
 }
 
 fn filter_messages_since_summary(messages: Vec<ChatMessage>) -> Vec<ChatMessage> {
+    // Filter out all messages up to and including the last summary
     let mut summary_found = false;
     let mut messages = messages
         .into_iter()
         .rev()
         .filter(|m| {
             if summary_found {
-                return matches!(m, ChatMessage::System(_));
+                return false;
             }
             if let ChatMessage::Summary(_) = m {
                 summary_found = true;


### PR DESCRIPTION
Fixes #253 
Related to #312 
