### PR TITLE
feat: Significant improvements to Chain-of-Thought prompts 

### DIFF
--- a/kwaak.toml
+++ b/kwaak.toml
@@ -9,7 +9,7 @@ otel_enabled = true
 
 [commands]
 test = "RUST_LOG=kwaak=debug,swiftide=debug RUST_BACKTRACE=1 cargo test --no-fail-fast --color=never"
-coverage = "cargo llvm-cov nextest --no-clean --summary-only"
+coverage = "cargo llvm-cov --no-clean --summary-only"
 # lint_and_fix = "cargo clippy --fix --allow-dirty --allow-staged; cargo fmt"
 
 [git]

--- a/src/agent/agents/coding.rs
+++ b/src/agent/agents/coding.rs
@@ -180,6 +180,7 @@ pub fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "If you create a pull request, you must ensure the tests pass",
         "If you just want to run the tests, prefer running the tests over running coverage, as running tests is faster",
         "NEVER write or edit a file before having read it",
+        "After every tool use, include your observations, reasoning, and the next step",
 
         // Code writing
         "When writing code or tests, make sure this is idiomatic for the language",

--- a/src/agent/agents/coding.rs
+++ b/src/agent/agents/coding.rs
@@ -165,6 +165,7 @@ pub fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "Your first response to ANY user message, must ALWAYS be your thoughts on how to solve the problem",
         "Keep a neutral tone, refrain from using superlatives and unnecessary adjectives",
         "Your response must always include your observation, your reasoning for the next step you are going to take, and the next step you are going to take",
+        "The format of your response should be: Observation, Reasoning, Next step",
         "Think step by step",
 
         // Knowledge

--- a/src/agent/agents/coding.rs
+++ b/src/agent/agents/coding.rs
@@ -164,6 +164,7 @@ pub fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "Tool calls are in parallel. You can run multiple tool calls at the same time, but they must not rely on each other",
         "Your first response to ANY user message, must ALWAYS be your thoughts on how to solve the problem",
         "Keep a neutral tone, refrain from using superlatives and unnecessary adjectives",
+        "Your response must always include your observation, your reasoning for the next step you are going to take, and the next step you are going to take",
         "Think step by step",
 
         // Knowledge

--- a/src/agent/agents/delegate.rs
+++ b/src/agent/agents/delegate.rs
@@ -154,6 +154,7 @@ pub fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "When delegating to an agent, reference your instructions with full paths to the files involved",
         "When delegating to an agent, provide a clear definition of done",
         "When delegating to an agent, clearly state edge cases",
+        "After every tool use, include your observations, reasoning, and the next step",
 
         // Workflow
         "Focus on completing the task fully as requested by the user",

--- a/src/agent/agents/delegate.rs
+++ b/src/agent/agents/delegate.rs
@@ -135,6 +135,7 @@ pub fn build_system_prompt(repository: &Repository) -> Result<Prompt> {
         "Tool calls are in parallel. You can run multiple tool calls at the same time, but they must not rely on each other",
         "Your first response to ANY user message, must ALWAYS be your thoughts on how to solve the problem",
         "Keep a neutral tone, refrain from using superlatives and unnecessary adjectives",
+        "Your response must always include your observation, your reasoning for the next step you are going to take, and the next step you are going to take",
         "Think step by step",
 
         // Knowledge

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -220,7 +220,7 @@ fn filter_messages_since_summary(messages: Vec<ChatMessage>) -> Vec<ChatMessage>
                 return Some(ChatMessage::Assistant(Some(message), None));
             }
 
-            // For assistant mesages, we only keep those with messages in them
+            // For assistant messages, we only keep those with messages in them
             if let ChatMessage::Assistant(message, Some(..)) = &m {
                 if message.is_some() {
                     return Some(ChatMessage::Assistant(message.clone(), None));

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -133,7 +133,7 @@ impl ConversationSummarizer {
         indoc::formatdoc!(
             "
         # Goal
-        Summarize and review the conversation up to this point
+        Summarize and review the conversation up to this point. An agent has tried to achieve a goal, and you need to help them get there.
             
         ## Requirements
         * Only include the summary in your response and nothing else.
@@ -150,6 +150,8 @@ impl ConversationSummarizer {
             should be used.
         * Identify the bigger goal the user wanted to achieve and clearly restate it
         * If the goal is not yet achieved, reflect on why and provide a clear path forward
+        * In suggested next steps, talk in the future tense. For example: \"You should run the tests\"
+        * Do not provide the actual tool calls the agent should still make, provide the steps and necessary context instead. Assume the agent knows how to use the tools.
 
         {{% if diff -%}}
         ## Current changes made

--- a/src/agent/conversation_summarizer.rs
+++ b/src/agent/conversation_summarizer.rs
@@ -202,8 +202,9 @@ fn filter_messages_since_summary(messages: Vec<ChatMessage>) -> Vec<ChatMessage>
             if summary_found {
                 return None;
             }
-            if m.is_tool_output() {
-                return None;
+            if let ChatMessage::ToolOutput(tool_call,tool_output) = &m {
+                let message = format!("You ran a tool called: {} with the following arguments: {}\n The tool returned:\n{}", tool_call.name(), tool_call.args().unwrap_or("No arguments"), tool_output.content().unwrap_or("No output"));
+                return Some(ChatMessage::Assistant(Some(message), None));
             }
             if let ChatMessage::Assistant(message, Some(..)) = &m {
                 if message.is_some() {
@@ -273,7 +274,7 @@ mod tests {
             ChatMessage::new_summary("Summary message"),
             ChatMessage::new_user("User message 2"),
             ChatMessage::new_assistant(Some("Assistant message 2"), Some(vec![tool_call.clone()])),
-            ChatMessage::new_tool_output(tool_call, "Tool output me_ssage"),
+            ChatMessage::new_tool_output(tool_call, "Tool output message"),
         ];
 
         let filtered_messages = filter_messages_since_summary(messages);
@@ -283,6 +284,7 @@ mod tests {
                 ChatMessage::new_summary("Summary message"),
                 ChatMessage::new_user("User message 2"),
                 ChatMessage::new_assistant(Some("Assistant message 2"), None),
+                ChatMessage::new_assistant(Some("You ran a tool called: run_tests with the following arguments: No arguments\n The tool returned:\nTool output message"), None)
             ]
         );
     }

--- a/src/indexing/query.rs
+++ b/src/indexing/query.rs
@@ -43,7 +43,7 @@ pub fn build_query_pipeline<'b>(
     let lancedb =
         storage::get_lancedb(repository) as Arc<dyn Retrieve<SimilaritySingleEmbedding<()>>>;
     let search_strategy: SimilaritySingleEmbedding<()> = SimilaritySingleEmbedding::default()
-        .with_top_k(40)
+        .with_top_k(30)
         .to_owned();
 
     let prompt_template = Templates::from_file("agentic_answer_prompt.md")?;


### PR DESCRIPTION
Improvements here follow from experimenting with sonnet 3.7. Improves the CoT prompt by being more explicit on what it should include. Additionally tunes the summarization step to include more information (and what information). So far, the results are promising, especially with 3.7. Seems like a large leap forward.

Additionally reduced the initial context a bit. Still very much a heuristic, but it improves the initial boot performance significantly. We only want to ground the agent anyway, not provide the full solution.
