### PR TITLE
refactor: Simplify db code

### DIFF
--- a/src/indexing/garbage_collection.rs
+++ b/src/indexing/garbage_collection.rs
@@ -326,17 +326,14 @@ mod tests {
         node.metadata
             .insert(metadata_qa_code::NAME, "test".to_string());
 
-        let redb = storage::build_redb(&repository).unwrap().build().unwrap();
+        let redb = storage::build_redb(&repository).unwrap();
 
         {
             redb.set(&node).await;
         }
         assert!(redb.get(&node).await);
 
-        let lancedb = storage::build_lancedb(&repository)
-            .unwrap()
-            .build()
-            .unwrap();
+        let lancedb = storage::build_lancedb(&repository).unwrap();
 
         if let Err(error) = lancedb.setup().await {
             tracing::warn!(%error, "Error setting up LanceDB");

--- a/src/indexing/garbage_collection.rs
+++ b/src/indexing/garbage_collection.rs
@@ -4,7 +4,7 @@
 //! NOTE: If more general settings are added to Redb, better extract this to a more general place.
 
 use anyhow::Result;
-use std::{borrow::Cow, path::PathBuf, sync::Arc, time::SystemTime};
+use std::{borrow::Cow, path::PathBuf, time::SystemTime};
 use swiftide::{
     integrations::{lancedb::LanceDB, redb::Redb},
     traits::Persist,
@@ -18,8 +18,8 @@ const LAST_CLEANED_UP_AT: &str = "last_cleaned_up_at";
 pub struct GarbageCollector<'repository> {
     /// The last index date
     repository: Cow<'repository, Repository>,
-    lancedb: Arc<LanceDB>,
-    redb: Arc<Redb>,
+    lancedb: LanceDB,
+    redb: Redb,
     /// Extensions to consider for GC
     file_extensions: Vec<&'repository str>,
 }
@@ -296,8 +296,8 @@ mod tests {
     use super::*;
 
     struct TestContext {
-        redb: Arc<Redb>,
-        lancedb: Arc<LanceDB>,
+        redb: Redb,
+        lancedb: LanceDB,
         node: Node,
         subject: GarbageCollector<'static>,
         _guard: TestGuard,
@@ -326,19 +326,18 @@ mod tests {
         node.metadata
             .insert(metadata_qa_code::NAME, "test".to_string());
 
-        let redb = Arc::new(storage::build_redb(&repository).unwrap().build().unwrap());
+        let redb = storage::build_redb(&repository).unwrap().build().unwrap();
 
         {
             redb.set(&node).await;
         }
         assert!(redb.get(&node).await);
 
-        let lancedb = Arc::new(
-            storage::build_lancedb(&repository)
-                .unwrap()
-                .build()
-                .unwrap(),
-        );
+        let lancedb = storage::build_lancedb(&repository)
+            .unwrap()
+            .build()
+            .unwrap();
+
         if let Err(error) = lancedb.setup().await {
             tracing::warn!(%error, "Error setting up LanceDB");
         }

--- a/src/indexing/query.rs
+++ b/src/indexing/query.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use anyhow::Result;
 use indoc::formatdoc;
 use swiftide::{
     query::{
         self, answers, query_transformers, search_strategies::SimilaritySingleEmbedding, states,
-        Query, Retrieve,
+        Query,
     },
     traits::{EmbeddingModel, SimplePrompt},
 };
@@ -40,8 +38,7 @@ pub fn build_query_pipeline<'b>(
         .embedding_provider()
         .get_embedding_model(backoff)?;
 
-    let lancedb =
-        storage::get_lancedb(repository) as Arc<dyn Retrieve<SimilaritySingleEmbedding<()>>>;
+    let lancedb = storage::get_lancedb(repository);
     let search_strategy: SimilaritySingleEmbedding<()> = SimilaritySingleEmbedding::default()
         .with_top_k(30)
         .to_owned();

--- a/src/indexing/repository.rs
+++ b/src/indexing/repository.rs
@@ -9,8 +9,6 @@ use swiftide::indexing::loaders;
 use swiftide::indexing::transformers;
 use swiftide::indexing::Node;
 use swiftide::traits::EmbeddingModel;
-use swiftide::traits::NodeCache;
-use swiftide::traits::Persist;
 use swiftide::traits::SimplePrompt;
 
 use super::garbage_collection::GarbageCollector;
@@ -49,7 +47,7 @@ pub async fn index_repository(
         .get_embedding_model(backoff)?;
 
     let lancedb = storage::get_lancedb(repository);
-    let redb = storage::get_redb(repository) as Arc<dyn NodeCache>;
+    let redb = storage::get_redb(repository);
 
     let total_chunks = Arc::new(AtomicU64::new(0));
     let processed_chunks = Arc::new(AtomicU64::new(0));
@@ -146,7 +144,7 @@ pub async fn index_repository(
                 Ok(node)
             }
         })
-        .then_store_with(Arc::clone(&lancedb) as Arc<dyn Persist>)
+        .then_store_with(lancedb)
         .run()
         .await?;
 

--- a/src/runtime_settings.rs
+++ b/src/runtime_settings.rs
@@ -3,8 +3,6 @@
 //! Unlike the configuration, these can during runtime, and are only intended to be used for
 //! internal operation of kwaak.
 
-use std::sync::Arc;
-
 use anyhow::{Context, Result};
 use redb::TableDefinition;
 use serde::{Deserialize, Serialize};
@@ -15,7 +13,7 @@ use crate::{repository::Repository, storage};
 const TABLE: TableDefinition<&str, &str> = TableDefinition::new("runtime_settings");
 
 pub struct RuntimeSettings {
-    db: Arc<Redb>,
+    db: Redb,
 }
 
 impl RuntimeSettings {
@@ -27,7 +25,7 @@ impl RuntimeSettings {
     }
 
     #[must_use]
-    pub fn from_db(db: Arc<Redb>) -> Self {
+    pub fn from_db(db: Redb) -> Self {
         Self { db }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,10 +4,11 @@
 
 use std::sync::OnceLock;
 
-use anyhow::Result;
-use swiftide::indexing::{transformers, EmbeddedField};
-use swiftide::integrations::lancedb::{LanceDB, LanceDBBuilder};
-use swiftide::integrations::redb::{Redb, RedbBuilder};
+use anyhow::{Context, Result};
+use swiftide::{
+    indexing::{transformers, EmbeddedField},
+    integrations::{lancedb::LanceDB, redb::Redb},
+};
 
 use crate::repository::Repository;
 
@@ -21,12 +22,7 @@ static REDB: OnceLock<Redb> = OnceLock::new();
 /// Panics if it cannot setup lancedb
 pub fn get_lancedb(repository: &Repository) -> LanceDB {
     LANCE_DB
-        .get_or_init(|| {
-            build_lancedb(repository)
-                .expect("Failed to build LanceDB")
-                .build()
-                .expect("Failed to build LanceDB")
-        })
+        .get_or_init(|| build_lancedb(repository).expect("Failed to build LanceDB"))
         .to_owned()
 }
 
@@ -36,51 +32,40 @@ pub fn get_lancedb(repository: &Repository) -> LanceDB {
 ///
 /// Panic if it cannot setup redb, i.e. its already open
 pub fn get_redb(repository: &Repository) -> Redb {
-    REDB.get_or_init(|| {
-        build_redb(repository)
-            .expect("Failed to build Redb")
-            .build()
-            .expect("Failed to build Redb")
-    })
-    .to_owned()
+    REDB.get_or_init(|| build_redb(repository).expect("Failed to build Redb"))
+        .to_owned()
 }
 
-pub(crate) fn build_lancedb(repository: &Repository) -> Result<LanceDBBuilder> {
+pub(crate) fn build_lancedb(repository: &Repository) -> Result<LanceDB> {
     let config = repository.config();
-    let mut cache_dir = config.cache_dir().to_owned();
-    cache_dir.push("lancedb");
+    let cache_dir = config.cache_dir().join("lancedb");
 
-    tracing::debug!("Building LanceDB with cache dir: {:?}", cache_dir);
+    tracing::debug!("Building LanceDB with cache dir: {}", cache_dir.display());
 
     let embedding_provider = config.embedding_provider();
 
-    Ok(LanceDB::builder()
-        .uri(
-            cache_dir
-                .to_str()
-                .ok_or(anyhow::anyhow!("Failed to convert path to string"))?,
-        )
+    let uri = cache_dir
+        .to_str()
+        .context("Failed to convert path to string")?;
+    LanceDB::builder()
+        .uri(uri)
         .with_vector(EmbeddedField::Combined)
         .vector_size(embedding_provider.vector_size())
         .table_name(&config.project_name)
         .with_metadata("path")
         .with_metadata(transformers::metadata_qa_code::NAME)
         .with_metadata(transformers::metadata_qa_text::NAME)
-        .to_owned())
+        .build()
 }
 
-#[allow(clippy::unnecessary_wraps)]
-pub(crate) fn build_redb(repository: &Repository) -> Result<RedbBuilder> {
+pub(crate) fn build_redb(repository: &Repository) -> Result<Redb> {
     let config = repository.config();
-    let mut cache_dir = config.cache_dir().to_owned();
-    cache_dir.push("redb");
+    let cache_dir = config.cache_dir().join("redb");
 
-    tracing::debug!("Building Redb with cache dir: {:?}", cache_dir);
+    tracing::debug!("Building Redb with cache dir: {}", cache_dir.display());
 
-    let redb_builder = Redb::builder()
+    Redb::builder()
         .database_path(cache_dir)
         .table_name(&config.project_name)
-        .to_owned();
-
-    Ok(redb_builder)
+        .build()
 }


### PR DESCRIPTION
commit 4c7c6cfc5ce58443fd3627be092af802c6e9ca64

    refactor: simplify db init code

commit 8d4146614c4f5c422302a62ec18f31b45c16f2a7

    chore: remove unnecessary Arc wrappers around DB
    
    A fairly common pattern in types which implement clients (db, web, etc.)
    is to have an inner type which is Arc wrapped. Both LanceDB and Redb are
    such types. This commit replaces the unnecessary Arc wrappers around
    these types in the storage module and all the places where they are used
    with a simple owned type which is cloned when needed.

---

Note: this is something I noticed when taking a bit of a quick read through the code base. I haven't been able to get kwaak working due to https://github.com/bosun-ai/kwaak/issues/338, so unsure if this is working correctly. Slapping the PR up regardless. Also, I do note that the db types carry a bit of config data around which is not Arc wrapped. This seems intuitively like it's small enough that it's unlikely to be a performance burden (order of magnitude 100s of bytes), and not data which is expected to be mutated by multiple code paths (there's no Mutex on the db types), so this data seems reasonable to clone when necessary.

Another approach to this might be to not have the statics and instead just creating the db values once, passing them between methods and cloning as needed. I haven't looked fully at the usage patterns to understand whether this approach would be appropriate, but it is something that generally works better than using global state like this.