### PR TITLE
style: don't use dark grey and dim together

### DIFF
--- a/src/frontend/chat_mode/message_formatting.rs
+++ b/src/frontend/chat_mode/message_formatting.rs
@@ -14,11 +14,11 @@ mod message_styles {
         .fg(Color::Rgb(200, 160, 255))
         .add_modifier(Modifier::BOLD);
 
-    pub const SYSTEM: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::DIM);
+    pub const SYSTEM: Style = Style::new().add_modifier(Modifier::DIM);
 
     pub const TOOL_DONE: Style = Style::new().fg(Color::Green).add_modifier(Modifier::DIM);
 
-    pub const TOOL_CALLED: Style = Style::new().fg(Color::DarkGray).add_modifier(Modifier::DIM);
+    pub const TOOL_CALLED: Style = Style::new().add_modifier(Modifier::DIM);
 
     pub const COMMAND: Style = Style::new()
         .fg(Color::LightMagenta)


### PR DESCRIPTION
On my color theme these make the text incredibly difficult to read.
Dim on its own works pretty well in many sitations.

---

The style I personally use is Aardvaark blue. I created this specifically for TUI usage after not finding a theme which met all the following criteria:

1. colors matched their name (i.e. yellow is not orange)
2. colors have enough contrast to work against the all of the following: default background, black, white, dark grey, grey
3. normal and bright versions of the colors are different
4. the default background was not black or white
5. shades of greys were properly ordered (i.e. black, dark grey, grey, white, bright white)

We use it for all the Ratatui screenshots.

See:
- https://github.com/ratatui/ratatui/blob/main/examples/README.md#color-explorer
- https://github.com/mbadolato/iTerm2-Color-Schemes#aardvark-blue