### PR TITLE
feat: Concept github triage via tools

### DIFF
--- a/src/agent/tools/github.rs
+++ b/src/agent/tools/github.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result};
+use swiftide::{
+    chat_completion::{errors::ToolError, ToolOutput},
+    traits::{AgentContext, Command},
+};
+use swiftide_macros::Tool;
+
+use crate::git::github::GithubSession;
+use crate::{templates::Templates, util::accept_non_zero_exit};
+
+#[derive(Tool, Clone)]
+#[tool(
+    description = "Search code on github with the github search api. Useful for finding code and documentation that is not otherwise available.",
+    param(
+        name = "query",
+        description = "Github search query (compatible with github search api"
+    )
+)]
+pub struct GithubSearchCode {
+    github_session: Arc<GithubSession>,
+}
+
+impl GithubSearchCode {
+    pub fn new(github_session: &Arc<GithubSession>) -> Self {
+        Self {
+            github_session: Arc::clone(github_session),
+        }
+    }
+
+    pub async fn github_search_code(
+        &self,
+        _context: &dyn AgentContext,
+        query: &str,
+    ) -> Result<ToolOutput, ToolError> {
+        let mut results = self.github_session.search_code(query).await?;
+
+        tracing::debug!(?results, "Github search results");
+
+        let mut context = tera::Context::new();
+        context.insert("items", &results.take_items());
+
+        let rendered = Templates::render("github_search_results.md", &context)
+            .map(Into::into)
+            .context("Failed to render github search results")?;
+
+        Ok(rendered)
+    }
+}
+
+#[derive(Tool, Clone, Debug)]
+#[tool(
+    description = "Creates or updates a pull request on Github. Always present the url of the pull request to the user after the tool call. Present the user with the url of the pull request after completion. Use conventional commits format for the title, such as `feat:`, `fix:`, `docs:`.",
+    param(name = "title", description = "Title of the pull request"),
+    param(name = "pull_request_body", description = "Body of the pull request")
+)]
+pub struct CreateOrUpdatePullRequest {
+    github_session: Arc<GithubSession>,
+}
+
+impl CreateOrUpdatePullRequest {
+    pub fn new(github_session: &Arc<GithubSession>) -> Self {
+        Self {
+            github_session: Arc::clone(github_session),
+        }
+    }
+
+    async fn create_or_update_pull_request(
+        &self,
+        context: &dyn AgentContext,
+        title: &str,
+        pull_request_body: &str,
+    ) -> Result<ToolOutput, ToolError> {
+        // Create a new branch
+        let cmd = Command::Shell("git rev-parse --abbrev-ref HEAD".to_string());
+        let branch_name = accept_non_zero_exit(context.exec_cmd(&cmd).await)?
+            .to_string()
+            .trim()
+            .to_string();
+
+        let cmd = Command::Shell(format!("git add . && git commit -m '{title}'"));
+        accept_non_zero_exit(context.exec_cmd(&cmd).await)?;
+
+        // Commit changes
+        // Push the current branch first
+        let cmd = Command::Shell("git push origin HEAD".to_string());
+        accept_non_zero_exit(context.exec_cmd(&cmd).await)?;
+
+        // Any errors we just forward to the llm at this point
+        let response = self
+            .github_session
+            .create_or_update_pull_request(
+                branch_name,
+                &self.github_session.main_branch(),
+                title,
+                pull_request_body,
+                &context.history().await
+            )
+            .await
+            .map(
+                |pr| {
+                    pr.html_url.map_or_else(
+                        || {
+                            "No pull request url found, are you sure you committed and pushed your changes?"
+                                .to_string()
+                        },
+                        |url| url.to_string(),
+                    )
+                },
+            ).context("Failed to create or update pull request")?;
+
+        Ok(response.into())
+    }
+}

--- a/src/agent/tools/github.rs
+++ b/src/agent/tools/github.rs
@@ -113,3 +113,44 @@ impl CreateOrUpdatePullRequest {
         Ok(response.into())
     }
 }
+
+// TODO:
+// list issues
+#[tool(
+    description = "list issues from the associated github repository, returns a list of issues with their titles, the issue number. The result is paginated.",
+    param(
+        name = "page",
+        description = "The page number of the issues to fetch. Always start with 0."
+    )
+)]
+#[derive(Tool, Clone, Debug)]
+pub struct ListIssues {
+    github_session: Arc<GithubSession>,
+}
+
+impl ListIssues {
+    pub fn new(github_session: &Arc<GithubSession>) -> Self {
+        Self {
+            github_session: Arc::clone(github_session),
+        }
+    }
+
+    pub async fn list_issues(
+        &self,
+        context: &dyn AgentContext,
+        page: usize,
+    ) -> Result<ToolOutput, ToolError> {
+        let issues = self.github_session.list_issues(page).await?;
+
+        let context =
+            tera::Context::from_serialize(issues).context("Failed to serialize issues")?;
+        let output = Templates::render("github_list_issues.md", &issues)
+            .map(Into::into)
+            .context("Failed to render github list issues")?;
+
+        Ok(output.into())
+    }
+}
+// search issues
+// fetch issue
+// comment issue

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -1,7 +1,9 @@
 mod delegate_agent;
+mod github;
 mod replace_lines;
 
 pub use delegate_agent::DelegateAgent;
+pub use github::*;
 pub use replace_lines::replace_lines;
 
 use std::sync::Arc;
@@ -19,7 +21,6 @@ use tokio::sync::Mutex;
 
 use crate::{
     config::ApiKey,
-    git::github::GithubSession,
     templates::Templates,
     util::{self, accept_non_zero_exit},
 };
@@ -232,71 +233,6 @@ impl<'a> ExplainCode<'a> {
 
 #[derive(Tool, Clone, Debug)]
 #[tool(
-    description = "Creates or updates a pull request on Github. Always present the url of the pull request to the user after the tool call. Present the user with the url of the pull request after completion. Use conventional commits format for the title, such as `feat:`, `fix:`, `docs:`.",
-    param(name = "title", description = "Title of the pull request"),
-    param(name = "pull_request_body", description = "Body of the pull request")
-)]
-pub struct CreateOrUpdatePullRequest {
-    github_session: Arc<GithubSession>,
-}
-
-impl CreateOrUpdatePullRequest {
-    pub fn new(github_session: &Arc<GithubSession>) -> Self {
-        Self {
-            github_session: Arc::clone(github_session),
-        }
-    }
-
-    async fn create_or_update_pull_request(
-        &self,
-        context: &dyn AgentContext,
-        title: &str,
-        pull_request_body: &str,
-    ) -> Result<ToolOutput, ToolError> {
-        // Create a new branch
-        let cmd = Command::Shell("git rev-parse --abbrev-ref HEAD".to_string());
-        let branch_name = accept_non_zero_exit(context.exec_cmd(&cmd).await)?
-            .to_string()
-            .trim()
-            .to_string();
-
-        let cmd = Command::Shell(format!("git add . && git commit -m '{title}'"));
-        accept_non_zero_exit(context.exec_cmd(&cmd).await)?;
-
-        // Commit changes
-        // Push the current branch first
-        let cmd = Command::Shell("git push origin HEAD".to_string());
-        accept_non_zero_exit(context.exec_cmd(&cmd).await)?;
-
-        // Any errors we just forward to the llm at this point
-        let response = self
-            .github_session
-            .create_or_update_pull_request(
-                branch_name,
-                &self.github_session.main_branch(),
-                title,
-                pull_request_body,
-                &context.history().await
-            )
-            .await
-            .map(
-                |pr| {
-                    pr.html_url.map_or_else(
-                        || {
-                            "No pull request url found, are you sure you committed and pushed your changes?"
-                                .to_string()
-                        },
-                        |url| url.to_string(),
-                    )
-                },
-            ).context("Failed to create or update pull request")?;
-
-        Ok(response.into())
-    }
-}
-
-#[derive(Tool, Clone, Debug)]
-#[tool(
     description = "Runs tests in the current project. Run this in favour of coverage, as it is typically faster."
 )]
 pub struct RunTests {
@@ -403,45 +339,6 @@ impl SearchWeb {
             .context("Failed to render search web results")?;
 
         Ok(rendered.into())
-    }
-}
-
-#[derive(Tool, Clone)]
-#[tool(
-    description = "Search code on github with the github search api. Useful for finding code and documentation that is not otherwise available.",
-    param(
-        name = "query",
-        description = "Github search query (compatible with github search api"
-    )
-)]
-pub struct GithubSearchCode {
-    github_session: Arc<GithubSession>,
-}
-
-impl GithubSearchCode {
-    pub fn new(github_session: &Arc<GithubSession>) -> Self {
-        Self {
-            github_session: Arc::clone(github_session),
-        }
-    }
-
-    pub async fn github_search_code(
-        &self,
-        _context: &dyn AgentContext,
-        query: &str,
-    ) -> Result<ToolOutput, ToolError> {
-        let mut results = self.github_session.search_code(query).await?;
-
-        tracing::debug!(?results, "Github search results");
-
-        let mut context = tera::Context::new();
-        context.insert("items", &results.take_items());
-
-        let rendered = Templates::render("github_search_results.md", &context)
-            .map(Into::into)
-            .context("Failed to render github search results")?;
-
-        Ok(rendered)
     }
 }
 


### PR DESCRIPTION
Work in progress.

The idea to start with is to just give the agent access to the tools so it can do its thing. After that, we can use the same utils/tools for other things.

Todo

- [ ] Add tools
- [ ] Add opt out configuration for the specific tools
- [ ] Do some testing
