### PR TITLE
fix(build): Compile time recursion limit back to default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "256"] // Temporary fix so tracing plays nice with lancedb
 pub mod agent;
 pub mod chat;
 pub mod chat_message;


### PR DESCRIPTION
Previously this was configured to have tracing play nice with lancedb. Doesn't seem to be necessary anymore.

I'm not sure if it's just a limit or also affects optimizations. Either way doesn't hurt to remove.
