### PR TITLE
feat: Check for updates on boot with a more compact header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3904,6 +3924,7 @@ dependencies = [
  "tui-logger",
  "tui-markdown",
  "tui-textarea",
+ "update-informer",
  "url",
  "uuid",
 ]
@@ -8529,6 +8550,20 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "update-informer"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53813bf5d5f0d8430794f8cc48e99521cc9e298066958d16383ccb8b39d182a7"
+dependencies = [
+ "etcetera",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "ureq",
+]
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,17 @@ htmd = "0.1.6"
 ansi-to-tui = "7.0.0"
 tempfile = { version = "3.16.0" }
 backoff = "0.4.0"
-
 copypasta = "0.10.1"
 strip-ansi-escapes = "0.2.1"
 inquire = "0.7.5"
 config = { version = "0.15.6", features = ["toml", "convert-case"] }
 dyn-clone = "1.0.17"
 shell-escape = "0.1.5"
+update-informer = { version = "1.2.0", features = [
+  "crates",
+  "ureq",
+  "rustls-tls",
+], default-features = false }
 
 # Something is still pulling in libssl, this is a quickfix and should be investigated
 [target.'cfg(linux)'.dependencies]

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 use strum::IntoEnumIterator as _;
 use tui_logger::TuiWidgetState;
 use tui_textarea::TextArea;
-use update_informer::{http_client::HttpClient, registry, Check};
+use update_informer::{registry, Check};
 use uuid::Uuid;
 
 use ratatui::{
@@ -150,8 +150,7 @@ impl Default for App<'_> {
         let command_responder = AppCommandResponder::spawn_for(ui_tx.clone());
 
         // Actual api checks are done only once every 24 hours, with the first happening after 24
-
-        let update_available = update_informer::new(registry::Crates, "kwaak", "0.1.0")
+        let update_available = update_informer::new(registry::Crates, "kwaak", VERSION)
             // .interval(Duration::ZERO) // Uncomment me to test the update informer
             .check_version()
             .ok()

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, ListState, Padding, Paragraph, Tabs},
+    widgets::{Block, ListState, Padding, Paragraph, Tabs},
 };
 
 use crossterm::event::{self, KeyCode, KeyEvent};
@@ -29,7 +29,7 @@ use super::{
 };
 
 const TICK_RATE: u64 = 250;
-const HEADER: &str = include_str!("ascii_logo");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Handles user and TUI interaction
 pub struct App<'a> {
@@ -288,7 +288,7 @@ impl App<'_> {
         loop {
             // Draw the UI
             terminal.draw(|f| {
-                if self.has_indexed_on_boot && self.splash.is_rendered() {
+                if self.has_indexed_on_boot {
                     self.render_tui(f);
                 } else {
                     self.splash.render(f);
@@ -499,28 +499,23 @@ impl App<'_> {
         }
 
         let [top_area, main_area] =
-            Layout::vertical([Constraint::Length(6), Constraint::Min(0)]).areas(f.area());
+            Layout::vertical([Constraint::Length(2), Constraint::Min(0)]).areas(f.area());
 
         // Hardcoded tabs length for now to right align
         let [header_area, tabs_area] =
             Layout::horizontal([Constraint::Fill(1), Constraint::Length(24)]).areas(top_area);
 
         Tabs::new(self.tab_names.iter().copied())
-            .block(
-                Block::default()
-                    .borders(Borders::BOTTOM)
-                    .padding(Padding::top(top_area.height - 2)),
-            )
+            .block(Block::default().padding(Padding::new(0, 1, 1, 0)))
             .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
             .select(self.selected_tab)
             .render(tabs_area, f.buffer_mut());
 
-        Paragraph::new(HEADER)
-            .block(
-                Block::default()
-                    .borders(Borders::BOTTOM)
-                    .padding(Padding::new(1, 0, 1, 0)),
-            )
+        let duck = Span::styled("󰇥", Style::default().fg(Color::Yellow));
+        let header = Span::styled("  kwaak  ", Style::default().bold());
+        let version = Span::styled(VERSION, Style::default().fg(Color::Gray));
+        Paragraph::new(duck + header + version)
+            .block(Block::default().padding(Padding::new(1, 0, 1, 0)))
             .render(header_area, f.buffer_mut());
 
         main_area

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, time::Duration};
 use strum::IntoEnumIterator as _;
 use tui_logger::TuiWidgetState;
 use tui_textarea::TextArea;
-use update_informer::{http_client::HttpClient, registry, Check, UpdateInformer};
+use update_informer::{http_client::HttpClient, registry, Check};
 use uuid::Uuid;
 
 use ratatui::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "256"] // Temporary fix so tracing plays nice with lancedb
 pub mod agent;
 pub mod chat;
 pub mod chat_message;


### PR DESCRIPTION
When there is an update available:

<img width="1905" alt="image" src="https://github.com/user-attachments/assets/817b33e9-301e-4e99-b6c1-58c18425ce52" />

When there is no update available:

<img width="1905" alt="image" src="https://github.com/user-attachments/assets/7e42aeaa-1de7-49b5-a510-195b34c62172" />

Resolves #284 