### PR TITLE
feat: Session recordings

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,6 +4,7 @@ mod conversation_summarizer;
 pub mod env_setup;
 pub mod running_agent;
 pub mod session;
+mod session_recording;
 mod tool_summarizer;
 pub mod tools;
 mod util;

--- a/src/agent/session_recording.rs
+++ b/src/agent/session_recording.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use swiftide::chat_completion::ChatMessage;
+
+use crate::repository::Repository;
+
+use super::session::Session;
+
+// A session is recording represents a session at a given point in time
+//
+// Use cases:
+// - Session replay
+// - Session persistance
+// - Testing, evaluation and benchmarking
+//
+// A session should be able to create a recording at any point in time.
+//
+// A session can also be resumed from a recording.
+//
+// TODO:
+// - Needs latest Swiftide for deriving Serialize and Deserialize
+// - How are we going to deal multiple agents? (Move active agent to session and deserialize that?)
+//   > Maybe a session should be a trait instead
+// - Should the recording get the diff, or should it be created with the diff?
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecording {
+    chat_messages: Vec<ChatMessage>,
+    diff: Option<String>,
+    repository: Repository,
+}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,11 +1,12 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, str::FromStr as _};
 
 use tokio::fs;
 
 use crate::{config::Config, runtime_settings::RuntimeSettings};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Repository {
     config: Config,
     path: PathBuf,


### PR DESCRIPTION
A session is recording represents a session at a given point in time

Use cases:

- Session replay
- Session persistance
- Testing, evaluation and benchmarking

Still musing a bit here on the design. I'm thinking to have the first PR just allow a --record, which saves it to a file and a --resume, which opens it in the first chat. In a follow up we could persist it to duckdb

TODO:

- Needs latest Swiftide for deriving Serialize and Deserialize
- How are we going to deal multiple agents? (Move active agent to session and deserialize that?)
  > Maybe a session should be a trait instead? Also could open the door for custom setups
- Should the recording get the diff, or should it be created with the diff?
