### PR TITLE
refactor: Remove Uuid from command responses and implement default members

### DIFF
--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -93,7 +93,7 @@ impl CommandHandler {
 
                 joinset.spawn(async move {
                     let result = this_handler.lock().await.handle_command_event(&repository, &event, &event.command()).await;
-                    event.responder().send(CommandResponse::Completed(event.uuid()));
+                    event.responder().send(CommandResponse::Completed);
 
                     if let Err(error) = result {
                         tracing::error!(?error, cmd = %event.command(), "Failed to handle command {cmd} with error {error:#}", cmd= event.command());

--- a/src/evaluations/tests/mod.rs
+++ b/src/evaluations/tests/mod.rs
@@ -1,7 +1,6 @@
 use super::logging_responder::LoggingResponder;
 use crate::commands::{CommandResponse, Responder};
 use swiftide::chat_completion::ChatMessage;
-use uuid::Uuid;
 
 #[test]
 fn test_logging_responder_formatting() {
@@ -18,11 +17,8 @@ fn test_logging_responder_formatting() {
     responder.agent_message(chat_message);
 
     // Test command response with escaped characters
-    let uuid = Uuid::new_v4();
-    let command_response = CommandResponse::BackendMessage(
-        uuid,
-        r#"Message with "quotes" and \n newlines"#.to_string(),
-    );
+    let command_response =
+        CommandResponse::BackendMessage(r#"Message with "quotes" and \n newlines"#.to_string());
     responder.send(command_response);
 
     // Test system message with escaped characters
@@ -39,7 +35,7 @@ fn test_logging_responder_formatting() {
     assert!(log.contains(r#"Assistant(Some("Here's a message with "quotes" and "#));
     assert!(log.contains(r#"newlines and a JSON: {"key": "value"}")"#));
     assert!(log.contains(r"BackendMessage("));
-    assert!(log.contains(r#", "Message with "quotes" and "#));
+    assert!(log.contains(r#"Message with "quotes" and "#));
     assert!(log.contains("newlines"));
     assert!(log.contains(r#"System message with "quotes" and "#));
     assert!(log.contains("newlines"));

--- a/src/frontend/actions/diff.rs
+++ b/src/frontend/actions/diff.rs
@@ -30,7 +30,7 @@ pub async fn diff_show(app: &mut App<'_>) {
     let mut diff_message = String::new();
     while let Some(msg) = rx.recv().await {
         match msg {
-            CommandResponse::BackendMessage(_, ref payload) => {
+            CommandResponse::BackendMessage(ref payload) => {
                 if diff_message.is_empty() {
                     diff_message = payload.to_string();
                     let rendered = ansi_to_tui::IntoText::into_text(&diff_message).ok();
@@ -45,7 +45,7 @@ pub async fn diff_show(app: &mut App<'_>) {
                     app_tx.send(msg);
                 }
             }
-            CommandResponse::Completed(_) => {
+            CommandResponse::Completed => {
                 app_tx.send(msg);
                 break;
             }
@@ -83,12 +83,12 @@ pub async fn diff_pull(app: &mut App<'_>) {
 
     while let Some(msg) = rx.recv().await {
         match msg {
-            CommandResponse::BackendMessage(_, ref payload) => {
+            CommandResponse::BackendMessage(ref payload) => {
                 if branch.is_empty() {
                     branch = payload.to_string();
                 }
             }
-            CommandResponse::Completed(_) => {
+            CommandResponse::Completed => {
                 break;
             }
             _ => (),
@@ -112,12 +112,12 @@ pub async fn diff_pull(app: &mut App<'_>) {
     let mut diff = String::new();
     while let Some(msg) = rx.recv().await {
         match msg {
-            CommandResponse::BackendMessage(_, ref payload) => {
+            CommandResponse::BackendMessage(ref payload) => {
                 if diff.is_empty() {
                     diff = payload.to_string();
                 }
             }
-            CommandResponse::Completed(_) => {
+            CommandResponse::Completed => {
                 break;
             }
             _ => (),
@@ -145,7 +145,7 @@ pub async fn diff_pull(app: &mut App<'_>) {
 
         app.command_responder
             .for_chat_id(current_chat_uuid)
-            .send(CommandResponse::Completed(current_chat_uuid));
+            .send(CommandResponse::Completed);
         return;
     }
 
@@ -185,7 +185,7 @@ pub async fn diff_pull(app: &mut App<'_>) {
 
         app.command_responder
             .for_chat_id(current_chat_uuid)
-            .send(CommandResponse::Completed(current_chat_uuid));
+            .send(CommandResponse::Completed);
         return;
     }
     // add all changes
@@ -228,5 +228,5 @@ pub async fn diff_pull(app: &mut App<'_>) {
     // Tell the app that we are done
     app.command_responder
         .for_chat_id(current_chat_uuid)
-        .send(CommandResponse::Completed(current_chat_uuid));
+        .send(CommandResponse::Completed);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,18 +184,18 @@ async fn start_agent(
     let handle = tokio::spawn(async move {
         while let Some(response) = rx.recv().await {
             match response {
-                CommandResponse::Chat(.., message) => {
+                CommandResponse::Chat(message) => {
                     println!("{message}");
                 }
-                CommandResponse::Activity(.., message) => {
+                CommandResponse::Activity(message) => {
                     println!(">> {message}");
                 }
-                CommandResponse::BackendMessage(.., message) => {
+                CommandResponse::BackendMessage(message) => {
                     println!("Backend: {message}");
                 }
                 CommandResponse::RenameChat(..)
                 | CommandResponse::RenameBranch(..)
-                | CommandResponse::Completed(..) => {}
+                | CommandResponse::Completed => {}
             }
         }
     });


### PR DESCRIPTION
The Uuid wasn't needed anymore with the new design. The app now expects the responder to know where it should go (duh).

Also implemented default members. So now, if you want to implement a custom responder, all you need is `send(&self, response: Command::Response)`.
