### PR TITLE
feat: Rework tool configuration to support Opt-in as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,15 +386,22 @@ max_elapsed_time_sec = 120
 - **`agent_edit_mode`**: Defaults to `whole` (write full files at the time). If you experience issues with (very) large files, you can experiment with `line` edits.
 - **`git.auto_push_remote`**: Enabled by default if a github key is present. Automatically pushes to the remote repository after each chat completion. You can disable this by setting it to `false`.
 - **`git.auto_commit_disabled`**: Opt-out of automatic commits after each chat completion.
-- **`disabled_tools`**: A list of tool names to disable. NOTE not all tools are
-  enabled by default. For example: `disabled_tools = ["search_web",
-  "run_tests"]`.
-  Possible values: `"shell_command"`, `"read_file"`,
-  `"read_file_with_line_numbers"`, `"write_file"`, `"search_file"`, `"git"`,
-  `"reset_file"`, `"search_code"`, `"explain_code"`,
-  `"create_or_update_pull_request"`, `"run_tests"`, `"run_coverage"`,
-  `"search_web"`, `"github_search_code"`, `"fetch_url"`, `"add_lines"`,
-  `"replace_lines"`
+- **`tools`**: A list of tool names to enable or disable.
+  Example:
+
+```toml
+[tools]
+shell_command = false
+search_code = true
+```
+
+Possible values: `"shell_command"`, `"read_file"`,
+`"read_file_with_line_numbers"`, `"write_file"`, `"search_file"`, `"git"`,
+`"reset_file"`, `"search_code"`, `"explain_code"`,
+`"create_or_update_pull_request"`, `"run_tests"`, `"run_coverage"`,
+`"search_web"`, `"github_search_code"`, `"fetch_url"`, `"add_lines"`,
+`"replace_lines"`
+
 - **`ui.hide_header`**: Optionally hide the top header in the UI. Defaults to `false`.
 - **`num_completions_for_summary`**: Number of completions before the agent summarizes the conversation. Defaults to 10;
 - **`git.agent_user_name`**: Name which the kwaak agent will make commands with.

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -433,9 +433,9 @@ pub fn available_tools(
     tools.retain(|tool| {
         !repository
             .config()
-            .disabled_tools
+            .disabled_tools()
             .iter()
-            .any(|s| s == tool.name().as_ref())
+            .any(|s| *s == tool.name().as_ref())
     });
 
     Ok(tools)

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,18 +1,12 @@
 use config::{Config as ConfigRs, Environment, File};
 use std::{
-    borrow::Cow,
-    collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
 };
 
 use anyhow::{Context as _, Result};
-use serde::{
-    de::{MapAccess, Visitor},
-    ser::SerializeStruct as _,
-    Deserialize, Deserializer, Serialize, Serializer,
-};
+use serde::{Deserialize, Serialize};
 use swiftide::integrations::treesitter::SupportedLanguages;
 
 use super::defaults::{

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ mod command_configuration;
 mod config;
 pub mod defaults;
 mod llm_configuration;
+pub mod tools;
 
 pub use api_key::ApiKey;
 pub use command_configuration::*;

--- a/src/config/tools.rs
+++ b/src/config/tools.rs
@@ -1,0 +1,87 @@
+//! Configuration for enabling and disabling tools
+
+use std::{collections::HashMap, ops::Deref};
+
+use serde::{
+    de::{MapAccess, Visitor},
+    ser::SerializeStruct,
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+
+#[derive(Debug, Default, Clone)]
+pub struct Tools(HashMap<String, bool>);
+
+impl Deref for Tools {
+    type Target = HashMap<String, bool>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Serialize for Tools {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_some(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Tools {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ToolsVisitor;
+
+        impl<'de> Visitor<'de> for ToolsVisitor {
+            type Value = Tools;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a map of tool names to their enabled/disabled status")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                let mut tools = HashMap::new();
+
+                while let Some((key, value)) = map.next_entry::<String, bool>()? {
+                    tools.insert(key, value);
+                }
+
+                Ok(Tools(tools))
+            }
+        }
+
+        deserializer.deserialize_map(ToolsVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_serialize_tools() {
+        let mut tools = HashMap::new();
+        tools.insert("tool1".to_string(), true);
+        tools.insert("tool2".to_string(), false);
+        let tools = Tools(tools);
+
+        let serialized = serde_json::to_string(&tools).unwrap();
+        assert_eq!(serialized, r#"{"tool1":true,"tool2":false}"#);
+    }
+
+    #[test]
+    fn test_deserialize_tools() {
+        let json = r#"{"tool1":true,"tool2":false}"#;
+        let tools: Tools = serde_json::from_str(json).unwrap();
+
+        assert_eq!(tools.0.get("tool1"), Some(&true));
+        assert_eq!(tools.0.get("tool2"), Some(&false));
+    }
+}

--- a/src/config/tools.rs
+++ b/src/config/tools.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, ops::Deref};
 
 use serde::{
     de::{MapAccess, Visitor},
-    ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
 


### PR DESCRIPTION
After some thought I figured it would be nicer if users don't have to deal with the double negation. Additionally, there are also tools that are disabled by default. With this we can support both from the config level as well (even though we don't).

Bonus, we can (later) clean up session::available_tools and instead create the default list purely on the config. I feel that is where it belongs.

I think:

```toml
[tools]
write_file = false
run_tests = false
```

reads better than:

```toml
disabled_tools = ["write_file", "run_tests"]
```
