### PR TITLE
fix: Set Ollama embedding model correctly during onboarding

### DIFF
--- a/src/onboarding/llm.rs
+++ b/src/onboarding/llm.rs
@@ -6,7 +6,8 @@ use strum::VariantNames as _;
 
 use crate::{
     config::{
-        AnthropicModel, FastembedModel, LLMConfiguration, OpenAIEmbeddingModel, OpenAIPromptModel,
+        AnthropicModel, EmbeddingModelWithSize, FastembedModel, LLMConfiguration,
+        OpenAIEmbeddingModel, OpenAIPromptModel,
     },
     onboarding::util::prompt_text,
 };
@@ -268,8 +269,7 @@ fn ollama_questions(context: &mut tera::Context) -> Result<()> {
         &json!({
             "provider": "Ollama",
             "base_url": None::<String>,
-            "embedding_model": embedding_model,
-            "vector_size": vector_size,
+            "embedding_model": format!("{{name = \"{embedding_model}\", vector_size = {vector_size}}}")
         }),
     );
 

--- a/src/onboarding/llm.rs
+++ b/src/onboarding/llm.rs
@@ -6,8 +6,7 @@ use strum::VariantNames as _;
 
 use crate::{
     config::{
-        AnthropicModel, EmbeddingModelWithSize, FastembedModel, LLMConfiguration,
-        OpenAIEmbeddingModel, OpenAIPromptModel,
+        AnthropicModel, FastembedModel, LLMConfiguration, OpenAIEmbeddingModel, OpenAIPromptModel,
     },
     onboarding::util::prompt_text,
 };

--- a/src/onboarding/mod.rs
+++ b/src/onboarding/mod.rs
@@ -55,11 +55,14 @@ pub async fn run(file: Option<PathBuf>, dry_run: bool) -> Result<()> {
     let config =
         Templates::render("kwaak.toml", &context).context("Failed to render default config")?;
 
+    // Ensure we panic during tests
     debug_assert!(
         toml::from_str::<crate::config::Config>(&config).is_ok(),
-        "Failed to parse the rendered config with error: {error}, config: \n{config}",
+        "Failed to parse the rendered config with error: {error:#}, config: \n{config}",
         error = toml::from_str::<crate::config::Config>(&config).unwrap_err()
     );
+    toml::from_str::<crate::config::Config>(&config)
+        .context("There is an error in the configuration")?;
 
     // Since we want the template annotated with comments, just return the template
     if dry_run {

--- a/templates/kwaak.toml
+++ b/templates/kwaak.toml
@@ -87,7 +87,11 @@ base_url = "{{ llm.base_url }}"
 
 [llm.embedding]
 provider = "{{ embed_llm.provider }}"
+{% if embed_llm.provider == "Ollama" -%}
+embedding_model = {{ embed_llm.embedding_model }}
+{% else -%}
 embedding_model = "{{ embed_llm.embedding_model }}"
+{% endif -%}
 {% if llm.base_url -%}
 base_url = "{{ embed_llm.base_url }}"
 {% endif -%}


### PR DESCRIPTION
Proper fix can come later. Perhaps in #351. I.e. generate the real config types, then tie it all together in the toml file. Could also then resume from an existing toml. Additionally, any comments could maybe be pulled from doc comments.