### PR TITLE
chore: Use lld for faster local docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Always build against latest stable
 ARG RUST_VERSION=1.85
-FROM rust:${RUST_VERSION} AS builder
+FROM rust:${RUST_VERSION}
 
 # Install rust tools
 RUN rustup component add clippy rustfmt
@@ -18,17 +18,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libxcb-xfixes0-dev \
   libxcb1-dev \
   protobuf-compiler \
+  # Faster builds
+  lld \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-# Build dependencies so they can be cached in a docker layer
-COPY Cargo.toml Cargo.lock ./
-RUN mkdir src \
-  && echo 'fn main() { println!("ERROR in docker build"); }' > src/main.rs \
-  && cargo test --no-run \
-  && rm -rf src
-
-# Build the actual project
+# Build test binaries so we can get started right away
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 COPY . .
-RUN cargo test --no-run
+RUN --mount=type=cache,target=/app/target/ \
+  --mount=type=cache,target=/usr/local/cargo/git/db \
+  --mount=type=cache,target=/usr/local/cargo/registry/ \
+  cargo test --no-run

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,16 @@ WORKDIR /app
 
 # Build test binaries so we can get started right away
 ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+
+# Build dependencies so they can be cached in a docker layer
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src \
+  && echo 'fn main() { println!("ERROR in docker build"); }' > src/main.rs \
+  && cargo test --no-run \
+  && rm -rf src
+
+# Build the actual project
+# Build test binaries so we can get started right away
+ENV RUSTFLAGS="-C link-arg=-fuse-ld=lld"
 COPY . .
-RUN --mount=type=cache,target=/app/target/ \
-  --mount=type=cache,target=/usr/local/cargo/git/db \
-  --mount=type=cache,target=/usr/local/cargo/registry/ \
-  cargo test --no-run
+RUN cargo test --no-run


### PR DESCRIPTION
Pfft curb my enthousiasm, bind mounts only work during build. So back to the original solution. It does now use ldd instead of ld in the image. That solves my memory issues.