### PR TITLE
fix: Tool summarizer should escape output

### DIFF
--- a/src/agent/snapshots/kwaak__agent__tool_summarizer__test__prompt_render_where_tool_output_has_jinja.snap
+++ b/src/agent/snapshots/kwaak__agent__tool_summarizer__test__prompt_render_where_tool_output_has_jinja.snap
@@ -13,27 +13,14 @@ Reformat but do not summarize, all information should be preserved and detailed.
 
 Tool name: search_file
 Tool description: Searches for a file inside the current project, leave the argument empty to list all files. Uses `find`.
-Tool was called with arguments: {"query":"some_file"}
-
-## The agent has made the following changes
-
-````diff
-diff --git a/some_file b/some_file
-index 0000000..1111111 100644
---- a/some_file
-+++ b/some_file
-@@ -1,1 +1,1 @@
--old
-+new
-    
-````
+Tool was called with arguments: {"query":"some_file_with_jinja"}
 
 
 
 ## Tool output
 
 ````shell
-Found it!
+Result with Jinja syntax: {{ some_variable }}
 ````
 
 ## Format
@@ -43,8 +30,6 @@ Found it!
   available only.
 - If you do not have a clear solution, state that you do not have a clear solution.
 - If there is any mangling in the tool response, reformat it to be readable.
-- If you suspect that any changes made by the agent affect the tool output, mention
-  that. Make sure you include full paths to the files.
 
 
 ## Available tools

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,13 +1,15 @@
 use anyhow::Context as _;
 use anyhow::Result;
 use rust_embed::Embed;
+use swiftide::template::Template;
 use tera::Tera;
 
 #[derive(Embed)]
 #[folder = "templates"]
 pub struct Templates;
 
-// TODO: Would be nice if we could combine/replace this in a nice way with swiftide templates
+// TODO: Figure out if we can extend the tera template repository in swiftide templates with
+// /templates so that we can remove this
 impl Templates {
     pub fn render(name: &str, context: &tera::Context) -> Result<String> {
         let byte_file =
@@ -17,11 +19,24 @@ impl Templates {
         Tera::one_off(template, context, false).context("Failed to render template")
     }
 
-    // Should be zero need to allocate here but lazy day
     pub fn from_file(name: &str) -> Result<String> {
         let byte_file =
             Templates::get(name).with_context(|| format!("Expected template {name}"))?;
 
         String::from_utf8(byte_file.data.into_owned()).context("Failed to read template")
+    }
+
+    /// Load the template as a swiftide template
+    ///
+    /// Prefer this over the other methods, they'll be removed soon.
+    /// Intenrally Templates are a light wrapper around Tera with some shenanigans
+    pub fn load(name: &str) -> Result<Template> {
+        // Either we make sure included templates are rendered as static, or swiftide Templates
+        // should be Cow
+        let byte_file =
+            Templates::get(name).with_context(|| format!("Expected template {name}"))?;
+        let template = std::str::from_utf8(&byte_file.data)?.to_string();
+
+        Ok(template.into())
     }
 }

--- a/templates/tool_summarizer.md
+++ b/templates/tool_summarizer.md
@@ -1,7 +1,3 @@
----
-source: src/agent/tool_summarizer.rs
-expression: rendered_prompt.render().await.unwrap()
----
 # Goal
 
 A coding agent has made a tool call. It is your job to refine the output.
@@ -11,29 +7,29 @@ Reformat but do not summarize, all information should be preserved and detailed.
 
 ##
 
-Tool name: search_file
-Tool description: Searches for a file inside the current project, leave the argument empty to list all files. Uses `find`.
-Tool was called with arguments: {"query":"some_file"}
+Tool name: {{tool_name}}
+Tool description: {{tool_description}}
+Tool was called with arguments: {{tool_args}}
+
+{% if tool_name == 'run_tests' or tool_name == 'run_coverage' -%}
+
+If the tests pass, additionally mention that coverage must be checked such that
+it actually improved, did not stay the same, and the file executed properly.
+{% endif -%}
+{% if diff -%}
 
 ## The agent has made the following changes
 
 ````diff
-diff --git a/some_file b/some_file
-index 0000000..1111111 100644
---- a/some_file
-+++ b/some_file
-@@ -1,1 +1,1 @@
--old
-+new
-    
+{{diff}}
 ````
 
-
+{% endif %}
 
 ## Tool output
 
 ````shell
-Found it!
+{{tool_output}}
 ````
 
 ## Format
@@ -43,13 +39,14 @@ Found it!
   available only.
 - If you do not have a clear solution, state that you do not have a clear solution.
 - If there is any mangling in the tool response, reformat it to be readable.
+{% if diff -%}
 - If you suspect that any changes made by the agent affect the tool output, mention
   that. Make sure you include full paths to the files.
-
+{% endif %}
 
 ## Available tools
 
-- **search_file**: Searches for a file inside the current project, leave the argument empty to list all files. Uses `find`.
+{{formatted_tools}}
 
 ## Requirements
 


### PR DESCRIPTION
In the Django SWE results, the summarizer failed because there is inline jinja.

Reworked the template so it's a bit nicer. I'm sure it can be nicer still.
