### PR TITLE
refactor: Injectable storage

### DIFF
--- a/src/indexing/garbage_collection.rs
+++ b/src/indexing/garbage_collection.rs
@@ -318,7 +318,7 @@ mod tests {
         node.metadata
             .insert(metadata_qa_code::NAME, "test".to_string());
 
-        let duckdb = storage::build_duckdb(&repository).unwrap();
+        let duckdb = storage::build_duckdb(repository.config()).unwrap();
 
         {
             duckdb.set(&node).await;

--- a/src/runtime_settings.rs
+++ b/src/runtime_settings.rs
@@ -18,7 +18,7 @@ pub struct RuntimeSettings {
 impl RuntimeSettings {
     #[must_use]
     pub fn from_repository(repository: &Repository) -> Self {
-        let db = storage::get_duckdb(repository);
+        let db = storage::get_duckdb(repository.config());
 
         Self {
             db,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -16,7 +16,7 @@ use std::sync::OnceLock;
 use anyhow::{Context, Result};
 use swiftide::{indexing::EmbeddedField, integrations::duckdb::Duckdb};
 
-use crate::repository::Repository;
+use crate::{config::Config, repository::Repository};
 
 static DUCK_DB: OnceLock<Duckdb> = OnceLock::new();
 
@@ -25,16 +25,15 @@ static DUCK_DB: OnceLock<Duckdb> = OnceLock::new();
 /// # Panics
 ///
 /// Panics if it cannot setup duckdb
-pub fn get_duckdb(repository: &Repository) -> Duckdb {
+pub fn get_duckdb(config: &Config) -> Duckdb {
     DUCK_DB
-        .get_or_init(|| build_duckdb(repository).expect("Failed to build duckdb"))
+        .get_or_init(|| build_duckdb(config).expect("Failed to build duckdb"))
         .to_owned()
 }
 
 // Probably should just be on the repository/config, cloned from there.
 // This sucks in tests
-pub(crate) fn build_duckdb(repository: &Repository) -> Result<Duckdb> {
-    let config = repository.config();
+pub(crate) fn build_duckdb(config: &Config) -> Result<Duckdb> {
     let path = config.cache_dir().join("duck.db3");
 
     tracing::debug!("Building Duckdb: {}", path.display());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -277,7 +277,7 @@ pub async fn setup_integration() -> Result<IntegrationContext> {
     let (repository, repository_guard) = test_repository();
     let workdir = repository.path().clone();
     let mut app = App::default().with_workdir(repository.path());
-    let duckdb = storage::get_duckdb(&repository);
+    let duckdb = repository.storage();
     duckdb.setup().await.unwrap();
     let terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
 


### PR DESCRIPTION
Refactors Kwaak's internal storage so that it is injectable. Consumers that use kwaak as a library can then use their own, as long as it is supported by Swiftide.

This is an important step to be able to run Kwaak as a server.

To get this mergeable, the following still needs to happen:

- Upcasting should be added in Rust 1.86 (there's ugly ways I believe with any/downcast ref, but let's wait 2 weeks)
- Kwaak should provide a trait for secondary functionality (GC & runtime settings)
- There should be a way to set the storage when creating the repository (when used as a lib)
- Duckdb should be feature flagged
