### PR TITLE
feat: Extend kwaak with mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.15",
  "rexpect",
+ "rmcp",
  "rust-embed",
  "secrecy",
  "serde",
@@ -3283,7 +3284,7 @@ dependencies = [
  "swiftide",
  "swiftide-core",
  "swiftide-docker-executor",
- "swiftide-integrations",
+ "swiftide-integrations 0.22.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "swiftide-macros",
  "tavily",
  "tempfile",
@@ -5253,6 +5254,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ron"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5538,6 +5571,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5631,6 +5688,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6083,8 +6151,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7633fb3c1e754e955fdc890b70718e9dbd29d34f4f517a743d8d1c8fc74bb5f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6094,15 +6160,13 @@ dependencies = [
  "swiftide-agents",
  "swiftide-core",
  "swiftide-indexing",
- "swiftide-integrations",
+ "swiftide-integrations 0.22.6",
  "swiftide-query",
 ]
 
 [[package]]
 name = "swiftide-agents"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61006a8660218d2ed98f3ff069ba132c585d46ce01bb0710d54ecddfd3bad5dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6110,6 +6174,7 @@ dependencies = [
  "dyn-clone",
  "fs-err",
  "indoc",
+ "rmcp",
  "serde",
  "serde_json",
  "strum 0.27.1",
@@ -6122,8 +6187,6 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d8da1d36cc93d35b8727065b1de6b47645425614e78cd2e73219e6e5d3b8661"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6178,8 +6241,6 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559f71be9050ef156abbf2680017df5a1bd017af27cc199a75d9c3aac881ba2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6205,8 +6266,6 @@ dependencies = [
 [[package]]
 name = "swiftide-integrations"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e73d5843acda5cc01ecbfec69eca4d84b1747fd562b4e6de4d79df47de5ad2"
 dependencies = [
  "anyhow",
  "async-anthropic",
@@ -6248,10 +6307,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "swiftide-macros"
+name = "swiftide-integrations"
 version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552d0d0677d89cc0d17fc22534ceca446f27306d0a38242a3371ded5ec4231f9"
+checksum = "e9e73d5843acda5cc01ecbfec69eca4d84b1747fd562b4e6de4d79df47de5ad2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "derive_builder 0.20.2",
+ "fastembed",
+ "fs-err",
+ "futures-util",
+ "itertools 0.14.0",
+ "regex",
+ "reqwest 0.12.15",
+ "serde",
+ "serde_json",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
+ "swiftide-core",
+ "swiftide-macros",
+ "tera",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "swiftide-macros"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6268,8 +6353,6 @@ dependencies = [
 [[package]]
 name = "swiftide-query"
 version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda3198042b1b698e9fc91d1cb97f89c60948dd4706f95456f90d22f374c5c7b"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ swiftide = { version = "0.22.6", features = [
   "mcp",
 
 ] }
-rmcp = { version = "0.1.0", features = ["transport-child-process"] }
+rmcp = { version = "0.1.0", features = ["transport-child-process", "client"] }
 swiftide-macros = { version = "0.22.6" }
 swiftide-integrations = { version = "0.22.6" }
 fastembed = "4.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["rt"] }
 strum = "0.27.1"
 strum_macros = "0.27.1"
-swiftide = { version = "=0.22.6", features = [
+swiftide = { version = "0.22.6", features = [
   "openai",
   "tree-sitter",
   "ollama",
@@ -33,10 +33,12 @@ swiftide = { version = "=0.22.6", features = [
   "fastembed",
   "anthropic",
   "duckdb",
+  "mcp",
 
 ] }
-swiftide-macros = { version = "=0.22.6" }
-swiftide-integrations = { version = "=0.22.6" }
+rmcp = { version = "0.1.0", features = ["transport-child-process"] }
+swiftide-macros = { version = "0.22.6" }
+swiftide-integrations = { version = "0.22.6" }
 fastembed = "4.6.0"
 toml = "0.8.20"
 serde = { version = "1.0.218", features = ["derive"] }
@@ -152,9 +154,10 @@ evaluations = []
 # diffy = { git = "https://github.com/timonv/diffy", branch = "fix/debug-wrong-line" }
 # arrow = { version = "=53.2.0", optional = false }
 # arrow-arith = { version = "=53.2.0", optional = false }
-# swiftide = { path = "../swiftide/swiftide" }
-# swiftide-macros = { path = "../swiftide/swiftide-macros" }
-# swiftide-core = { path = "../swiftide/swiftide-core" }
+swiftide = { path = "../swiftide/swiftide" }
+swiftide-macros = { path = "../swiftide/swiftide-macros" }
+swiftide-core = { path = "../swiftide/swiftide-core" }
+swiftide-agents = { path = "../swiftide/swiftide-agents" }
 
 [workspace.metadata.cross.target.x86_64-unknown-linux-gnu]
 image = "rust:1.83.0"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Kwaak uses patch based editing by default. This means that only the changed line
 
 ### Configuration
 
-Kwaak supports configuring different Large Language Models (LLMs) for distinct tasks like indexing, querying, and embedding to optimize performance and accuracy. Be sure to tailor the configurations to fit the scope and blend of the tasks you're tackling.
+Kwaak supports configuring different Large Language Models (LLMs) for distinct tasks like indexing, querying, and embedding to optimize performance and accuracy. Be sure to tailor the configurations to fit the scope and blend of the tasks you're tackling. Configuration is done in a `kwaak.toml` file in the root of the project, and can be overridden by a `kwaak.local.toml` file and/or via ENV variables.
 
 #### General Configuration
 
@@ -260,6 +260,32 @@ Kwaak uses tests, coverages, and lints as an additional opportunity to steer the
 - **`test`**: Command to run tests, e.g., `cargo test`.
 - **`coverage`**: Command for running coverage checks, e.g., `cargo llvm-cov --summary-only`. Expects coverage results as output. Currently handled unparsed via an LLM call. A friendly output is preferred
 - **`lint_and_fix`**: Optional command to lint and fix project issues, e.g., `cargo clippy --fix --allow-dirty; cargo fmt` in Rust.
+
+#### Custom tools via MCP
+
+The community has made many amazing tools available via the MCP protocol. Kwaak can be extended with these.
+
+Example:
+
+```toml
+[[mcp]]
+# A name for your convenience
+name = "server-everything"
+
+# The command and arguments to start up the mcp server
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-everything"]
+
+# Optionally whitelist or blacklist tools
+filter = { type = "whitelist", tool_names = ["add"] }
+
+# Optionally set environment variables. Values are assumed to be secret and follow the same syntax as api keys (prefixed with env:, text:, or file:)
+env = {
+  SECRET_CALCULATOR_API_KEY = "env:SECRET_CALCULATOR_API_KEY"
+}
+```
+
+You can verify the mcp tools work by listing them with `kwaak --allow-dirty list-tools`.
 
 #### API Key Management
 

--- a/src/agent/agents/coding.rs
+++ b/src/agent/agents/coding.rs
@@ -7,6 +7,7 @@ use swiftide::{
     prompt::Prompt,
     traits::{AgentContext, Command, SimplePrompt, ToolExecutor},
 };
+use swiftide_core::ToolBox;
 
 use crate::{
     agent::{
@@ -22,7 +23,7 @@ use crate::{
 pub async fn start(
     session: &Session,
     executor: &Arc<dyn ToolExecutor>,
-    tools: &[Box<dyn Tool>],
+    tool_boxes: &[Box<dyn ToolBox>],
     agent_env: &AgentEnvironment,
     initial_context: String,
 ) -> Result<RunningAgent> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -52,6 +52,8 @@ pub enum Commands {
         tool_name: String,
         tool_args: Option<String>,
     },
+    /// Lists all built-in tools and mcp tools
+    ListTools,
     /// Print the configuration and exit
     PrintConfig,
     /// Clear the index and cache for this project and exit

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -15,7 +15,7 @@ use super::{
         default_auto_push_remote, default_cache_dir, default_docker_context, default_dockerfile,
         default_log_dir, default_main_branch, default_project_name,
     },
-    mcp::McpTool,
+    mcp::McpServer,
 };
 use super::{CommandConfiguration, LLMConfiguration, LLMConfigurations};
 
@@ -152,7 +152,7 @@ pub struct Config {
 
     /// Add tools from MCP servers to the agents
     #[serde(default)]
-    pub mcp: Option<Vec<McpTool>>,
+    pub mcp: Option<Vec<McpServer>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -9,11 +9,14 @@ use anyhow::{Context as _, Result};
 use serde::{Deserialize, Serialize};
 use swiftide::integrations::treesitter::SupportedLanguages;
 
-use super::defaults::{
-    default_auto_push_remote, default_cache_dir, default_docker_context, default_dockerfile,
-    default_log_dir, default_main_branch, default_project_name,
-};
 use super::{api_key::ApiKey, tools::Tools};
+use super::{
+    defaults::{
+        default_auto_push_remote, default_cache_dir, default_docker_context, default_dockerfile,
+        default_log_dir, default_main_branch, default_project_name,
+    },
+    mcp::McpTool,
+};
 use super::{CommandConfiguration, LLMConfiguration, LLMConfigurations};
 
 #[allow(clippy::struct_excessive_bools)]
@@ -146,6 +149,10 @@ pub struct Config {
     /// Defaults to 10.
     #[serde(default = "default_num_completions_for_summary")]
     pub num_completions_for_summary: usize,
+
+    /// Add tools from MCP servers to the agents
+    #[serde(default)]
+    pub mcp: Option<Vec<McpTool>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -1,13 +1,157 @@
 use serde::{Deserialize, Serialize};
-// TODO:
-//
-// Support whitelists/blacklists
-// Error handling?
+use swiftide::agents::tools::mcp::ToolFilter;
+
+use super::ApiKey;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", content = "value")]
-pub enum McpTool {
+#[serde(untagged)]
+pub enum McpServer {
     /// Spawns the mcp server in a sub process
-    Process { cmd: String },
-    // Sse support, need to consider auth, etc
-    // Url(url)
+    SubProcess {
+        /// The name of the mcp server
+        name: String,
+        /// The main command to run
+        command: String,
+        /// Any arguments to pass to the the command
+        #[serde(default)]
+        args: Vec<String>,
+        /// Any filters to apply to the tools
+        #[serde(default, with = "opt_ext_tool_filter")]
+        filter: Option<ToolFilter>,
+        #[serde(default)]
+        /// Any environment variables to set
+        env: Option<Vec<(String, ApiKey)>>,
+    },
+}
+
+// Wraps the swiftide tool filter so we can control how it is serialized
+//
+// In toml it looks like this:
+//
+// ```toml
+// filter = { type = "whitelist", tool_names = ["tool1", "tool2"] }
+//
+// # or
+//
+// [mcp.filter]
+// type = "whitelist"
+// tool_names = ["tool1", "tool2"]
+// ```
+mod opt_ext_tool_filter {
+    use super::ToolFilter;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+    #[serde(
+        remote = "ToolFilter",
+        tag = "type",
+        content = "tool_names",
+        rename_all = "snake_case"
+    )]
+    pub enum ToolFilterDef {
+        Whitelist(Vec<String>),
+        Blacklist(Vec<String>),
+    }
+
+    #[allow(clippy::ref_option, reason = "not with serde")]
+    pub fn serialize<S>(value: &Option<ToolFilter>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Helper<'a>(#[serde(with = "ToolFilterDef")] &'a ToolFilter);
+
+        value.as_ref().map(Helper).serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<ToolFilter>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper(#[serde(with = "ToolFilterDef")] ToolFilter);
+
+        let helper = Option::deserialize(deserializer)?;
+        Ok(helper.map(|Helper(external)| external))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use toml; // Make sure to include `toml` in your `Cargo.toml` dependencies
+
+    #[test]
+    fn test_deserialize_subprocess_basic() {
+        let toml_data = r#"
+            name = "test_server"
+            command = "run"
+        "#;
+
+        let server: McpServer = toml::from_str(toml_data).expect("Deserialization failed");
+
+        match server {
+            McpServer::SubProcess {
+                name,
+                command,
+                args,
+                filter,
+                env,
+            } => {
+                assert_eq!(name, "test_server");
+                assert_eq!(command, "run");
+                assert!(args.is_empty());
+                assert!(filter.is_none());
+                assert!(env.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn test_deserialize_subprocess_with_args() {
+        let toml_data = r#"
+            name = "test_server"
+            command = "run"
+            args = ["--verbose", "--debug"]
+        "#;
+
+        let server: McpServer = toml::from_str(toml_data).expect("Deserialization failed");
+
+        match server {
+            McpServer::SubProcess {
+                name,
+                command,
+                args,
+                ..
+            } => {
+                assert_eq!(name, "test_server");
+                assert_eq!(command, "run");
+                assert_eq!(args, vec!["--verbose".to_string(), "--debug".to_string()]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_deserialize_subprocess_with_filter() {
+        let toml_data = r#"
+            name = "test_server"
+            command = "run"
+            
+            [filter]
+            type = "whitelist"
+            tool_names = ["tool1", "tool2"]
+        "#;
+
+        let server: McpServer = toml::from_str(toml_data).expect("Deserialization failed");
+
+        if let McpServer::SubProcess {
+            filter: Some(ToolFilter::Whitelist(opts)),
+            ..
+        } = server
+        {
+            assert_eq!(opts, vec!["tool1".to_string(), "tool2".to_string()]);
+        } else {
+            panic!("Expected McpServer::SubProcess with filter");
+        }
+    }
 }

--- a/src/config/mcp.rs
+++ b/src/config/mcp.rs
@@ -1,0 +1,13 @@
+use serde::{Deserialize, Serialize};
+// TODO:
+//
+// Support whitelists/blacklists
+// Error handling?
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum McpTool {
+    /// Spawns the mcp server in a sub process
+    Process { cmd: String },
+    // Sse support, need to consider auth, etc
+    // Url(url)
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,6 +4,7 @@ mod command_configuration;
 mod config;
 pub mod defaults;
 mod llm_configuration;
+pub mod mcp;
 pub mod tools;
 
 pub use api_key::ApiKey;

--- a/src/evaluations/patch.rs
+++ b/src/evaluations/patch.rs
@@ -1,7 +1,7 @@
 //! The patch module is meant to reveal problems in agents when making modifications to the source code. Specifically
 //! in large files and/or files with semantic whitespace.
 
-use crate::agent::session::available_tools;
+use crate::agent::session::available_builtin_tools;
 use crate::config::Config;
 use crate::evaluations::{
     logging_responder::LoggingResponder,
@@ -219,7 +219,7 @@ async fn run_single_evaluation(iteration: u32) -> Result<(bool, EvalMetrics)> {
 
     let repository = Repository::from_config(config);
 
-    let tools = available_tools(&repository, None, None)?;
+    let tools = available_builtin_tools(&repository, None, None)?;
     let agent =
         start_tool_evaluation_agent(&repository, responder.clone(), tools, &prompt()).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::config::Config;
-use agent::session::available_tools;
+use agent::session::available_builtin_tools;
 use anyhow::{Context as _, Result};
 use clap::Parser;
 use commands::CommandResponse;
@@ -14,7 +14,8 @@ use git::github::GithubSession;
 #[cfg(feature = "evaluations")]
 use kwaak::evaluations;
 use kwaak::{
-    agent, cli, commands, config, frontend, git,
+    agent::{self, session::start_mcp_toolboxes},
+    cli, commands, config, frontend, git,
     indexing::{self, index_repository},
     onboarding, repository, storage,
 };
@@ -39,6 +40,7 @@ use uuid::Uuid;
 mod test_utils;
 
 #[tokio::main]
+#[allow(clippy::too_many_lines)] // I know, I know, it's not.
 async fn main() -> Result<()> {
     let args = cli::Args::parse();
 
@@ -89,6 +91,28 @@ async fn main() -> Result<()> {
                 start_agent(repository, initial_message, &args).await
             }
             cli::Commands::Tui => start_tui(&repository, &args).await,
+            cli::Commands::ListTools => {
+                let github_session = Arc::new(GithubSession::from_repository(&repository)?);
+                let tools = available_builtin_tools(&repository, Some(&github_session), None)?;
+
+                println!("**Enabled built-in tools:**");
+                for tool in tools {
+                    println!(" - {}", tool.name());
+                }
+
+                let mcp_toolboxes = start_mcp_toolboxes(&repository).await?;
+
+                println!("\n**MCP tools:**");
+                for toolbox in mcp_toolboxes {
+                    println!("::{}", toolbox.name());
+
+                    for tool in toolbox.available_tools().await? {
+                        println!(" - {}", tool.name());
+                    }
+                }
+
+                Ok(())
+            }
             cli::Commands::Index => index_repository(&repository, None).await,
             cli::Commands::TestTool {
                 tool_name,
@@ -154,7 +178,7 @@ async fn test_tool(
     tool_args: Option<&str>,
 ) -> Result<()> {
     let github_session = Arc::new(GithubSession::from_repository(&repository)?);
-    let tool = available_tools(repository, Some(&github_session), None)?
+    let tool = available_builtin_tools(repository, Some(&github_session), None)?
         .into_iter()
         .find(|tool| tool.name() == tool_name)
         .context("Tool not found")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,6 +108,7 @@ async fn main() -> Result<()> {
 
                     for tool in toolbox.available_tools().await? {
                         println!(" - {}", tool.name());
+                        println!("{:?}", tool.tool_spec());
                     }
                 }
 


### PR DESCRIPTION
Enables extending kwaak with MCP. Requires bosun-ai/swiftide#658

The community has made many amazing tools available via the MCP protocol. Kwaak can be extended with these.

Example:

```toml
[[mcp]]
# A name for your convenience
name = "server-everything"

# The command and arguments to start up the mcp server
command = "npx"
args = ["-y", "@modelcontextprotocol/server-everything"]

# Optionally whitelist or blacklist tools
filter = { type = "whitelist", tool_names = ["add"] }

# Optionally set environment variables. Values are assumed to be secret and follow the same syntax as api keys (prefixed with env:, text:, or file:)
env = {
  SECRET_CALCULATOR_API_KEY = "env:SECRET_CALCULATOR_API_KEY"
}
```

You can verify the mcp tools work by listing them with `kwaak --allow-dirty list-tools`.
