### PR TITLE
refactor: Index behind an interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,40 +747,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core 0.4.5",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.2",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
-dependencies = [
- "axum-core 0.5.2",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -802,25 +776,6 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
-dependencies = [
- "bytes",
- "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -998,7 +953,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "tonic 0.12.3",
+ "tonic",
  "tower-service",
  "url",
  "winapi",
@@ -1012,7 +967,7 @@ checksum = "4565dfbe8ac1deb443211d55a1985cc33fd9d3606cf86377edbb538682993f30"
 dependencies = [
  "prost",
  "prost-types",
- "tonic 0.12.3",
+ "tonic",
  "ureq",
 ]
 
@@ -3628,12 +3583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4209,7 +4158,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
  "prost",
- "tonic 0.12.3",
+ "tonic",
 ]
 
 [[package]]
@@ -6133,9 +6082,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.23.0"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f91868c84fe80d23d76b77711102d26c74067234d946f9d8ac253a2cbdecc72"
+checksum = "cda57adb4d38ccccd539100ebe4ea3d0f25786f47467c27a40d5d545b76d7a73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6151,9 +6100,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.23.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41cee50b33eb748da269ed9ff7608912b5cec06cc697059e21893b30031bf05"
+checksum = "61006a8660218d2ed98f3ff069ba132c585d46ce01bb0710d54ecddfd3bad5dc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6166,16 +6115,15 @@ dependencies = [
  "strum 0.27.1",
  "strum_macros 0.27.1",
  "swiftide-core",
- "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "swiftide-core"
-version = "0.23.0"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb9434bb4913006b58294f3f720c42e7a2f7207ad2e7ad151d8c0e574e3eefe"
+checksum = "790fc4f741c511ae210bcb62f108f9982ea80882c849c63e7034b8fbff904db9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6201,9 +6149,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-docker-executor"
-version = "0.7.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3360b573b2b23389a58b592a9d071d8f3d5b437a72fc85b2116840846d6d5c8"
+checksum = "f36912a4af5f69ef7bba290e8cfd169ec064bd87f1f1f2ecb6febfbd5c8a72eb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6220,7 +6168,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-tar",
- "tonic 0.13.0",
+ "tonic",
  "tonic-build",
  "tracing",
  "uuid",
@@ -6229,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.23.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6222fc29eec0684e2461d4e29de55e7be3621bc9a9cbe06a6d692e0642f1b2"
+checksum = "559f71be9050ef156abbf2680017df5a1bd017af27cc199a75d9c3aac881ba2a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6256,9 +6204,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.23.0"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac943ae767393e0118035fd362ddd794611b8f262462a7658517f8bd69540dd"
+checksum = "23e6d8bf901218d47e247b6a738e57098e589b13824501fa9f9d999c98d2fec5"
 dependencies = [
  "anyhow",
  "async-anthropic",
@@ -6301,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.23.0"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1feb725a0df2bd298d36aed999ea8273765f3086fba493c08d18d10136d85956"
+checksum = "46334386ba042461124528354fd9245235236b857e3bd7d67b8eeb181d64275d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6319,9 +6267,9 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.23.0"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e801e8e2e3fd23471c4a2ac368723c6a088b997c44f4ec137c8d958c8e0b082"
+checksum = "eda3198042b1b698e9fc91d1cb97f89c60948dd4706f95456f90d22f374c5c7b"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6913,7 +6861,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.8",
@@ -6936,39 +6884,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
-dependencies = [
- "async-trait",
- "axum 0.8.3",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.8",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2",
- "tokio",
- "tokio-stream",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -7006,9 +6925,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.8.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ arrow = { version = "=54.2.1" }
 # chrono = "=0.4.38"
 arrow-arith = { version = "=54.2.1" }
 
-swiftide-docker-executor = "0.7.1"
+swiftide-docker-executor = "0.7.0"
 anyhow = "1.0.97"
 crossterm = "0.28.1"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
@@ -24,7 +24,7 @@ tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["rt"] }
 strum = "0.27.1"
 strum_macros = "0.27.1"
-swiftide = { version = "=0.23.0", features = [
+swiftide = { version = "=0.22.7", features = [
   "openai",
   "tree-sitter",
   "ollama",
@@ -35,8 +35,8 @@ swiftide = { version = "=0.23.0", features = [
   "duckdb",
 
 ] }
-swiftide-macros = { version = "=0.23.0" }
-swiftide-integrations = { version = "=0.23.0" }
+swiftide-macros = { version = "=0.22.7" }
+swiftide-integrations = { version = "=0.22.7" }
 fastembed = "4.6.0"
 toml = "0.8.20"
 serde = { version = "1.0.218", features = ["derive"] }
@@ -108,7 +108,7 @@ test-log = { version = "0.2.17", features = ["trace"] }
 insta = "1.42.2"
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
-swiftide-core = { version = "=0.23.0", features = ["test-utils"] }
+swiftide-core = { version = "=0.22.7", features = ["test-utils"] }
 mockall = "0.13.1"
 rexpect = "0.6.0"
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,8 +7,10 @@ pub mod session;
 mod tool_summarizer;
 pub mod tools;
 mod util;
+use crate::{commands::Responder, indexing::Index, repository::Repository};
 use session::{RunningSession, Session};
 use std::sync::Arc;
+use uuid::Uuid;
 
 use anyhow::Result;
 
@@ -17,6 +19,7 @@ use anyhow::Result;
 pub async fn start_session(
     uuid: Uuid,
     repository: &Repository,
+    index: &impl Index,
     initial_query: &str,
     command_responder: Arc<dyn Responder>,
 ) -> Result<RunningSession> {
@@ -29,10 +32,6 @@ pub async fn start_session(
         .repository(repository.clone())
         .default_responder(command_responder)
         .initial_query(initial_query.to_string())
-        .start()
+        .start(index)
         .await
 }
-
-use uuid::Uuid;
-
-use crate::{commands::Responder, repository::Repository};

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -18,7 +18,7 @@ use crate::{
     commands::Responder,
     config::{self, AgentEditMode, SupportedToolExecutors},
     git::github::GithubSession,
-    indexing,
+    indexing::{self, Index},
     repository::Repository,
 };
 
@@ -79,7 +79,7 @@ impl Session {
 impl SessionBuilder {
     /// Starts a session
     #[tracing::instrument(skip_all)]
-    pub async fn start(&mut self) -> Result<RunningSession> {
+    pub async fn start(&mut self, index: &impl Index) -> Result<RunningSession> {
         let (running_session_tx, running_session_rx) = tokio::sync::mpsc::unbounded_channel();
 
         let session = Arc::new(
@@ -116,7 +116,7 @@ impl SessionBuilder {
                 &fast_query_provider,
                 &session.default_responder
             ),
-            generate_initial_context(&session.repository, &session.initial_query)
+            generate_initial_context(&session.repository, &session.initial_query, index)
         )?;
 
         let env_setup = EnvSetup::new(&session.repository, github_session.as_deref(), &*executor);
@@ -126,6 +126,7 @@ impl SessionBuilder {
             &session.repository,
             github_session.as_ref(),
             Some(&agent_environment),
+            index,
         )?;
 
         let active_agent = match session.repository.config().agent {
@@ -369,8 +370,12 @@ async fn start_tool_executor(uuid: Uuid, repository: &Repository) -> Result<Arc<
 }
 
 #[tracing::instrument(skip_all)]
-async fn generate_initial_context(repository: &Repository, query: &str) -> Result<String> {
-    let retrieved_context = indexing::query(repository, &query).await?;
+async fn generate_initial_context(
+    repository: &Repository,
+    query: &str,
+    index: &impl Index,
+) -> Result<String> {
+    let retrieved_context = index.query_repository(repository, &query).await?;
     let formatted_context = format!("Additional information:\n\n{retrieved_context}");
     Ok(formatted_context)
 }
@@ -379,8 +384,9 @@ pub fn available_tools(
     repository: &Repository,
     github_session: Option<&Arc<GithubSession>>,
     agent_env: Option<&env_setup::AgentEnvironment>,
+    index: &impl Index,
 ) -> Result<Vec<Box<dyn Tool>>> {
-    let query_pipeline = indexing::build_query_pipeline(repository, None)?;
+    let query_pipeline = index.build_query_pipeline(repository)?;
     let mut tools = vec![
         tools::write_file(),
         tools::search_file(),

--- a/src/agent/tools/mod.rs
+++ b/src/agent/tools/mod.rs
@@ -12,7 +12,7 @@ use swiftide::traits::CommandError;
 use anyhow::{Context as _, Result};
 use swiftide::{
     chat_completion::{errors::ToolError, ToolOutput},
-    query::{search_strategies, states},
+    query::{search_strategies, states, SearchStrategy},
     traits::{AgentContext, Command},
 };
 use swiftide_macros::{tool, Tool};
@@ -190,27 +190,13 @@ pub async fn search_code(context: &dyn AgentContext, query: &str) -> Result<Tool
         description = "A description, question, or literal code you want to know more about. Uses a semantic similarly search."
     )
 )]
-pub struct ExplainCode<'a> {
-    query_pipeline: Arc<
-        Mutex<
-            swiftide::query::Pipeline<
-                'a,
-                search_strategies::SimilaritySingleEmbedding,
-                states::Answered,
-            >,
-        >,
-    >,
+pub struct ExplainCode<'a, S: SearchStrategy> {
+    query_pipeline: Arc<Mutex<swiftide::query::Pipeline<'a, S, states::Answered>>>,
 }
 
-impl<'a> ExplainCode<'a> {
+impl<'a, S: SearchStrategy> ExplainCode<'a, S> {
     #[must_use]
-    pub fn new(
-        query_pipeline: swiftide::query::Pipeline<
-            'a,
-            search_strategies::SimilaritySingleEmbedding,
-            states::Answered,
-        >,
-    ) -> Self {
+    pub fn new(query_pipeline: swiftide::query::Pipeline<'a, S, states::Answered>) -> Self {
         Self {
             query_pipeline: Arc::new(Mutex::new(query_pipeline)),
         }

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -13,6 +13,7 @@ use crate::{
     frontend::App,
     git, indexing,
     repository::Repository,
+    storage,
     util::accept_non_zero_exit,
 };
 
@@ -126,7 +127,10 @@ impl CommandHandler {
                     .await?;
             }
             Command::IndexRepository => {
-                indexing::index_repository(repository, Some(event.clone_responder())).await?;
+                // TODO: This should be setup when starting the handler
+                let storage = storage::get_duckdb(repository);
+                indexing::index_repository(repository, storage, Some(event.clone_responder()))
+                    .await?;
             }
             Command::ShowConfig => {
                 event

--- a/src/commands/handler.rs
+++ b/src/commands/handler.rs
@@ -136,8 +136,6 @@ impl<I: Index + Clone + 'static> CommandHandler<I> {
                     .await?;
             }
             Command::IndexRepository => {
-                // TODO: This should be setup when starting the handler
-
                 index
                     .index_repository(repository, Some(event.clone_responder()))
                     .await?;

--- a/src/evaluations/patch.rs
+++ b/src/evaluations/patch.rs
@@ -8,6 +8,7 @@ use crate::evaluations::{
     output::{EvalMetrics, EvalOutput},
     start_tool_evaluation_agent,
 };
+use crate::indexing::DuckdbIndex;
 use crate::repository::Repository;
 use anyhow::Result;
 use std::fmt::Write as _;
@@ -223,7 +224,9 @@ async fn run_single_evaluation(iteration: u32) -> Result<(bool, EvalMetrics)> {
 
     let repository = Repository::from_config(config);
 
-    let tools = available_tools(&repository, None, None)?;
+    let kwaak_index = DuckdbIndex::default();
+
+    let tools = available_tools(&repository, None, None, &kwaak_index)?;
     let agent =
         start_tool_evaluation_agent(&repository, responder.clone(), tools, &prompt()).await?;
 

--- a/src/evaluations/ragas.rs
+++ b/src/evaluations/ragas.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use swiftide::query::evaluators::ragas;
 
-use crate::{indexing::build_query_pipeline, repository::Repository};
+use crate::{indexing::build_query_pipeline, repository::Repository, storage};
 
 /// Evaluate a query pipeline with RAGAS
 ///
@@ -58,7 +58,11 @@ pub async fn evaluate_query_pipeline(
 
     // Build query pipeline
     tracing::info!("Building query pipeline");
-    let pipeline = build_query_pipeline(repository, Some(Box::new(ragas.clone())))?;
+    let pipeline = build_query_pipeline(
+        repository,
+        &storage::get_duckdb(repository),
+        Some(Box::new(ragas.clone())),
+    )?;
 
     // Query all questions from the dataset
     tracing::info!("Querying all questions");

--- a/src/indexing/mod.rs
+++ b/src/indexing/mod.rs
@@ -3,6 +3,79 @@ mod progress_updater;
 mod query;
 mod repository;
 
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
 pub use query::build_query_pipeline;
 pub use query::query;
 pub use repository::index_repository;
+use swiftide::integrations::duckdb::Duckdb;
+use swiftide::query::{states, Pipeline};
+
+use crate::commands::Responder;
+use crate::repository::Repository;
+use crate::storage::get_duckdb;
+
+/// Interface that wraps storage providers
+#[async_trait]
+pub trait Index: Send + Sync + std::fmt::Debug {
+    type SearchStrategy: swiftide::query::SearchStrategy + 'static;
+
+    fn build_query_pipeline<'b>(
+        &self,
+        repository: &Repository,
+    ) -> Result<Pipeline<'b, Self::SearchStrategy, states::Answered>>;
+
+    async fn query_repository<'b>(
+        &self,
+        repository: &Repository,
+        query: impl AsRef<str> + Send,
+    ) -> Result<String>;
+
+    async fn index_repository<'b>(
+        &self,
+        repository: &Repository,
+        responder: Option<Arc<dyn Responder>>,
+    ) -> Result<()>;
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DuckdbIndex {}
+
+impl DuckdbIndex {
+    fn get_duckdb(&self, repository: &Repository) -> Duckdb {
+        get_duckdb(repository)
+    }
+}
+
+#[async_trait]
+impl Index for DuckdbIndex {
+    type SearchStrategy = swiftide::query::search_strategies::SimilaritySingleEmbedding<()>;
+
+    fn build_query_pipeline<'b>(
+        &self,
+        repository: &Repository,
+    ) -> Result<Pipeline<'b, Self::SearchStrategy, states::Answered>> {
+        let storage = self.get_duckdb(repository);
+        query::build_query_pipeline(repository, &storage, None)
+    }
+
+    async fn query_repository<'b>(
+        &self,
+        repository: &Repository,
+        query: impl AsRef<str> + Send,
+    ) -> Result<String> {
+        let storage = self.get_duckdb(repository);
+        query::query(repository, &storage, query).await
+    }
+
+    async fn index_repository<'b>(
+        &self,
+        repository: &Repository,
+        responder: Option<Arc<dyn Responder>>,
+    ) -> Result<()> {
+        let storage = self.get_duckdb(repository);
+        index_repository(repository, &storage, responder).await
+    }
+}

--- a/src/indexing/query.rs
+++ b/src/indexing/query.rs
@@ -6,18 +6,24 @@ use swiftide::{
         self, answers, query_transformers, search_strategies::SimilaritySingleEmbedding, states,
         Query,
     },
-    traits::{EmbeddingModel, Persist, SimplePrompt},
+    traits::{EmbeddingModel, Persist, Retrieve, SimplePrompt},
 };
 
 use crate::{repository::Repository, storage, templates::Templates, util::strip_markdown_tags};
 
 #[tracing::instrument(skip_all, err)]
-pub async fn query(repository: &Repository, query: impl AsRef<str>) -> Result<String> {
+pub async fn query<S>(
+    repository: &Repository,
+    storage: &S,
+    query: impl AsRef<str>,
+) -> Result<String>
+where
+    S: Retrieve<SimilaritySingleEmbedding> + Persist + Clone + 'static,
+{
     // Ensure the table exists to avoid dumb errors
-    let duckdb = storage::get_duckdb(repository);
-    let _ = duckdb.setup().await;
+    let _ = storage.setup().await;
 
-    let answer = build_query_pipeline(repository, None)?
+    let answer = build_query_pipeline(repository, storage, None)?
         .query(query.as_ref())
         .await?
         .answer()
@@ -30,10 +36,14 @@ pub async fn query(repository: &Repository, query: impl AsRef<str>) -> Result<St
 /// # Panics
 ///
 /// Should be infallible
-pub fn build_query_pipeline<'b>(
+pub fn build_query_pipeline<'b, S>(
     repository: &Repository,
+    storage: &S,
     evaluator: Option<Box<dyn EvaluateQuery>>,
-) -> Result<query::Pipeline<'b, SimilaritySingleEmbedding, states::Answered>> {
+) -> Result<query::Pipeline<'b, SimilaritySingleEmbedding, states::Answered>>
+where
+    S: Retrieve<SimilaritySingleEmbedding> + Clone + 'static,
+{
     let backoff = repository.config().backoff;
     let query_provider: Box<dyn SimplePrompt> = repository
         .config()
@@ -44,7 +54,6 @@ pub fn build_query_pipeline<'b>(
         .embedding_provider()
         .get_embedding_model(backoff)?;
 
-    let duckdb = storage::get_duckdb(repository);
     let search_strategy: SimilaritySingleEmbedding<()> = SimilaritySingleEmbedding::default()
         .with_top_k(30)
         .to_owned();
@@ -90,7 +99,7 @@ pub fn build_query_pipeline<'b>(
         .then_transform_query(query_transformers::Embed::from_client(
             embedding_provider.clone(),
         ))
-        .then_retrieve(duckdb)
+        .then_retrieve(storage.clone())
         // .then_transform_response(response_transformers::Summary::from_client(
         //     query_provider.clone(),
         // ))

--- a/src/indexing/repository.rs
+++ b/src/indexing/repository.rs
@@ -21,7 +21,7 @@ const MARKDOWN_CHUNK_RANGE: std::ops::Range<usize> = 100..1024;
 #[tracing::instrument(skip_all)]
 pub async fn index_repository<S>(
     repository: &Repository,
-    storage: S,
+    storage: &S,
     responder: Option<Arc<dyn Responder>>,
 ) -> Result<()>
 where
@@ -93,7 +93,7 @@ where
             Ok(chunk)
         })
         .then(updater.count_processed_fn())
-        .then_store_with(storage)
+        .then_store_with(storage.clone())
         .run()
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use git::github::GithubSession;
 use kwaak::evaluations;
 use kwaak::{
     agent, cli, commands, config, frontend, git,
-    indexing::{self, index_repository},
+    indexing::{self, index_repository, DuckdbIndex},
     onboarding, repository, storage,
 };
 
@@ -90,14 +90,16 @@ async fn main() -> Result<()> {
             }
             cli::Commands::Tui => start_tui(&repository, &args).await,
             cli::Commands::Index => {
-                index_repository(&repository, storage::get_duckdb(&repository), None).await
+                index_repository(&repository, &storage::get_duckdb(&repository), None).await
             }
             cli::Commands::TestTool {
                 tool_name,
                 tool_args,
             } => test_tool(&repository, tool_name, tool_args.as_deref()).await,
             cli::Commands::Query { query: query_param } => {
-                let result = indexing::query(&repository, query_param).await;
+                let result =
+                    indexing::query(&repository, &storage::get_duckdb(&repository), query_param)
+                        .await;
 
                 if let Ok(result) = result.as_deref() {
                     println!("{result}");
@@ -156,7 +158,8 @@ async fn test_tool(
     tool_args: Option<&str>,
 ) -> Result<()> {
     let github_session = Arc::new(GithubSession::from_repository(&repository)?);
-    let tool = available_tools(repository, Some(&github_session), None)?
+    let index = DuckdbIndex::default();
+    let tool = available_tools(repository, Some(&github_session), None, &index)?
         .into_iter()
         .find(|tool| tool.name() == tool_name)
         .context("Tool not found")?;
@@ -197,7 +200,7 @@ async fn start_agent(
     repository.config_mut().endless_mode = true;
 
     if !args.skip_indexing {
-        indexing::index_repository(&repository, storage::get_duckdb(&repository), None).await?;
+        indexing::index_repository(&repository, &storage::get_duckdb(&repository), None).await?;
     }
 
     let (tx, mut rx) = mpsc::unbounded_channel();
@@ -222,7 +225,9 @@ async fn start_agent(
     });
 
     let query = initial_message.to_string();
-    let agent = agent::start_session(Uuid::new_v4(), &repository, &query, Arc::new(tx)).await?;
+    let index = DuckdbIndex::default();
+    let agent =
+        agent::start_session(Uuid::new_v4(), &repository, &index, &query, Arc::new(tx)).await?;
 
     agent.active_agent().query(&query).await?;
     handle.abort();
@@ -259,7 +264,9 @@ async fn start_tui(repository: &repository::Repository, args: &cli::Args) -> Res
     }
 
     let app_result = {
-        let mut handler = commands::CommandHandler::from_repository(repository);
+        let kwaak_index = DuckdbIndex::default();
+        let mut handler =
+            commands::CommandHandler::from_repository_and_index(repository, kwaak_index);
         handler.register_ui(&mut app);
 
         let _guard = handler.start();

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,9 @@ async fn main() -> Result<()> {
                 start_agent(repository, initial_message, &args).await
             }
             cli::Commands::Tui => start_tui(&repository, &args).await,
-            cli::Commands::Index => index_repository(&repository, None).await,
+            cli::Commands::Index => {
+                index_repository(&repository, storage::get_duckdb(&repository), None).await
+            }
             cli::Commands::TestTool {
                 tool_name,
                 tool_args,
@@ -195,7 +197,7 @@ async fn start_agent(
     repository.config_mut().endless_mode = true;
 
     if !args.skip_indexing {
-        indexing::index_repository(&repository, None).await?;
+        indexing::index_repository(&repository, storage::get_duckdb(&repository), None).await?;
     }
 
     let (tx, mut rx) = mpsc::unbounded_channel();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,6 +12,7 @@ use tokio_util::task::AbortOnDropHandle;
 use uuid::Uuid;
 
 use crate::frontend;
+use crate::indexing::DuckdbIndex;
 use crate::{
     commands::CommandHandler, config::Config, frontend::App, git, repository::Repository, storage,
 };
@@ -282,7 +283,8 @@ pub async fn setup_integration() -> Result<IntegrationContext> {
     duckdb.setup().await.unwrap();
     let terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
 
-    let mut handler = CommandHandler::from_repository(repository.clone());
+    let index = DuckdbIndex::default();
+    let mut handler = CommandHandler::from_repository_and_index(repository.clone(), index);
     handler.register_ui(&mut app);
     let handler_guard = handler.start();
 

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use kwaak::agent::tools;
 use serde_json::json;
 use swiftide::agents::{tools::local_executor::LocalExecutor, DefaultContext};
-use swiftide_core::{AgentContext, ToolExecutor};
+use swiftide::traits::{AgentContext, ToolExecutor};
 use tempfile::tempdir;
 
 macro_rules! invoke {


### PR DESCRIPTION
Lays the ground for dependency injecting the index into the application. Instead of gross boundary violations everywhere, the command handler is now started with an Index (DuckdbIndex here).

Exact interface and changes will likely still change, but this puts it nicely at the seams. There's still some spots where the index could be used but isn't.

It enables the following future changes (where as I see it, the hard part is now done):

- Running the kwaak backend with a different database
- Running the same kwaak backend with different pipelines
- Running kwaak on multiple repositories
- Running the index in a hosted environment


Requires bosun-ai/swiftide#720 as I wanted the pipelines to be generic over the search strategy but tools didn't support generics.
