### PR TITLE
refactor: Prepare for multi repository support

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use ratatui::widgets::ScrollbarState;
 
@@ -25,7 +25,7 @@ pub struct Chat {
     // Whether to auto-tail the chat on new messages
     pub auto_tail: bool,
 
-    pub repository: Option<Repository>,
+    pub repository: Option<Arc<Repository>>,
 }
 
 impl Chat {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -25,10 +25,32 @@ pub struct Chat {
     // Whether to auto-tail the chat on new messages
     pub auto_tail: bool,
 
-    pub repository: Option<Arc<Repository>>,
+    pub repository: Arc<Repository>,
 }
 
 impl Chat {
+    pub fn from_repository(repository: Arc<Repository>) -> Self {
+        Self {
+            name: "Chat".to_string(),
+            uuid: uuid::Uuid::new_v4(),
+            branch_name: None,
+            messages: Vec::new(),
+            state: ChatState::default(),
+            new_message_count: 0,
+            completed_tool_call_ids: HashSet::new(),
+            vertical_scroll_state: ScrollbarState::default(),
+            vertical_scroll: 0,
+            num_lines: 0,
+            auto_tail: true,
+            repository,
+        }
+    }
+
+    pub fn with_name(&mut self, name: impl Into<String>) -> &mut Self {
+        self.name = name.into();
+        self
+    }
+
     pub fn add_message(&mut self, message: ChatMessage) {
         if !message.role().is_user() {
             self.new_message_count += 1;
@@ -79,35 +101,17 @@ pub enum ChatState {
     Ready,
 }
 
-impl Default for Chat {
-    fn default() -> Self {
-        Self {
-            name: "Chat".to_string(),
-            uuid: uuid::Uuid::new_v4(),
-            branch_name: None,
-            messages: Vec::new(),
-            state: ChatState::default(),
-            new_message_count: 0,
-            completed_tool_call_ids: HashSet::new(),
-            vertical_scroll_state: ScrollbarState::default(),
-            vertical_scroll: 0,
-            num_lines: 0,
-            auto_tail: true,
-            repository: None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use swiftide::chat_completion;
 
     use super::*;
-    use crate::chat_message::ChatMessage;
+    use crate::{chat_message::ChatMessage, test_utils::test_repository};
 
     #[test]
     fn test_add_message_increases_new_message_count() {
-        let mut chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
         let message = ChatMessage::new_system("Test message");
 
         chat.add_message(message);
@@ -118,7 +122,8 @@ mod tests {
 
     #[test]
     fn test_add_message_does_not_increase_new_message_count_for_user() {
-        let mut chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
         let message = ChatMessage::new_user("Test message");
 
         chat.add_message(message);
@@ -129,7 +134,8 @@ mod tests {
 
     #[test]
     fn test_add_message_tool_call() {
-        let mut chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
         let tool_call = chat_completion::ToolCall::builder()
             .id("tool_call_id")
             .name("some_tool")
@@ -146,7 +152,8 @@ mod tests {
 
     #[test]
     fn test_transition() {
-        let mut chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
         chat.transition(ChatState::Loading);
 
         assert!(chat.is_loading());
@@ -154,17 +161,18 @@ mod tests {
 
     #[test]
     fn test_is_loading() {
-        let chat = Chat {
-            state: ChatState::Loading,
-            ..Default::default()
-        };
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
+        chat.transition(ChatState::Loading);
 
         assert!(chat.is_loading());
     }
 
     #[test]
     fn test_is_tool_call_completed() {
-        let mut chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let mut chat = Chat::from_repository(repository.into());
+
         chat.completed_tool_call_ids
             .insert("tool_call_id".to_string());
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -29,6 +29,7 @@ pub struct Chat {
 }
 
 impl Chat {
+    #[must_use]
     pub fn from_repository(repository: Arc<Repository>) -> Self {
         Self {
             name: "Chat".to_string(),

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -45,6 +45,7 @@ pub enum Command {
 #[derive(Debug, Clone, Builder)]
 pub struct CommandEvent {
     command: Command,
+    #[builder(default)]
     repository: Option<Arc<Repository>>,
     uuid: Uuid,
     responder: Arc<dyn Responder>,
@@ -56,6 +57,7 @@ impl CommandEvent {
         CommandEventBuilder::default()
     }
 
+    #[must_use]
     pub fn repository(&self) -> Option<&Repository> {
         self.repository.as_deref()
     }

--- a/src/commands/command.rs
+++ b/src/commands/command.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use derive_builder::Builder;
 use uuid::Uuid;
 
+use crate::repository::Repository;
+
 use super::Responder;
 
 /// Commands are the main way to interact with the backend
@@ -16,7 +18,7 @@ pub enum Command {
     /// Cleanly stop the backend
     Quit,
 
-    /// Print the config the backend is using
+    /// Print the config the config for a repository
     ShowConfig,
 
     /// Re-index a repository
@@ -43,22 +45,19 @@ pub enum Command {
 #[derive(Debug, Clone, Builder)]
 pub struct CommandEvent {
     command: Command,
+    repository: Option<Arc<Repository>>,
     uuid: Uuid,
     responder: Arc<dyn Responder>,
 }
 
 impl CommandEvent {
     #[must_use]
-    pub fn quit() -> Self {
-        CommandEvent {
-            command: Command::Quit,
-            responder: Arc::new(()),
-            uuid: Uuid::new_v4(),
-        }
-    }
-    #[must_use]
     pub fn builder() -> CommandEventBuilder {
         CommandEventBuilder::default()
+    }
+
+    pub fn repository(&self) -> Option<&Repository> {
+        self.repository.as_deref()
     }
 
     #[must_use]
@@ -81,9 +80,18 @@ impl CommandEvent {
         Arc::clone(&self.responder)
     }
 
-    #[must_use]
-    pub fn with_uuid(mut self, uuid: Uuid) -> Self {
+    pub fn with_uuid(&mut self, uuid: Uuid) -> &mut Self {
         self.uuid = uuid;
+        self
+    }
+
+    pub fn with_repository(&mut self, repository: Arc<Repository>) -> &mut Self {
+        self.repository = Some(repository);
+        self
+    }
+
+    pub fn with_maybe_repository(&mut self, repository: Option<Arc<Repository>>) -> &mut Self {
+        self.repository = repository;
         self
     }
 }
@@ -128,7 +136,8 @@ mod tests {
             .responder(responder.clone())
             .build()
             .unwrap()
-            .with_uuid(new_uuid);
+            .with_uuid(new_uuid)
+            .to_owned();
 
         assert_eq!(event.uuid(), new_uuid);
     }

--- a/src/frontend/actions/github.rs
+++ b/src/frontend/actions/github.rs
@@ -12,11 +12,7 @@ pub async fn github_issue(app: &mut App<'_>, number: u64, uuid: Uuid) {
         return;
     };
 
-    let Some(ref repository) = chat.repository else {
-        app.add_chat_message(uuid, ChatMessage::new_system("No repository found in UI"));
-        return;
-    };
-    let github_session = match git::github::GithubSession::from_repository(repository) {
+    let github_session = match git::github::GithubSession::from_repository(&chat.repository) {
         Ok(session) => session,
         Err(e) => {
             app.add_chat_message(

--- a/src/frontend/actions/mod.rs
+++ b/src/frontend/actions/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use copypasta::{ClipboardContext, ClipboardProvider as _};
 use strum::{EnumMessage, IntoEnumIterator};
 
-use crate::{chat::Chat, chat_message::ChatMessage, commands::Command, templates::Templates};
+use crate::{chat_message::ChatMessage, commands::Command, templates::Templates};
 
 use super::{ui_input_command::UserInputCommand, App};
 
@@ -22,31 +22,26 @@ pub fn delete_chat(app: &mut App) {
     let uuid = app.current_chat_uuid;
     app.dispatch_command(uuid, Command::StopAgent);
     // Remove the chat with the given UUID
-    app.chats.retain(|chat| chat.uuid != uuid);
-
-    if app.chats.is_empty() {
-        app.add_chat(Chat::default());
-        app.chats_state.select(Some(0));
+    if app.chats.len() == 1 {
         app.add_chat_message(
             app.current_chat_uuid,
-            ChatMessage::new_system("Nice, you managed to delete the last chat!"),
+            ChatMessage::new_system("You cannot delete the last chat"),
         );
-    } else {
-        app.next_chat();
+        return;
     }
+
+    app.chats.retain(|chat| chat.uuid != uuid);
+
+    app.next_chat();
 }
 
 pub fn copy_last_message(app: &mut App) {
     let Some(last_message) = app
         .current_chat()
-        .and_then(|c| {
-            c.messages
-                .iter()
-                .filter(|m| {
-                    (m.role().is_assistant() || m.role().is_user()) && !m.content().is_empty()
-                })
-                .next_back()
-        })
+        .messages
+        .iter()
+        .filter(|m| (m.role().is_assistant() || m.role().is_user()) && !m.content().is_empty())
+        .next_back()
         .map(ChatMessage::content)
     else {
         app.add_chat_message(

--- a/src/frontend/actions/mod.rs
+++ b/src/frontend/actions/mod.rs
@@ -20,7 +20,6 @@ pub use scroll::{scroll_down, scroll_end, scroll_up};
 
 pub fn delete_chat(app: &mut App) {
     let uuid = app.current_chat_uuid;
-    app.dispatch_command(uuid, Command::StopAgent);
     // Remove the chat with the given UUID
     if app.chats.len() == 1 {
         app.add_chat_message(
@@ -29,6 +28,8 @@ pub fn delete_chat(app: &mut App) {
         );
         return;
     }
+
+    app.dispatch_command(uuid, Command::StopAgent);
 
     app.chats.retain(|chat| chat.uuid != uuid);
 

--- a/src/frontend/actions/scroll.rs
+++ b/src/frontend/actions/scroll.rs
@@ -1,9 +1,7 @@
 use crate::frontend::App;
 
 pub fn scroll_up(app: &mut App) {
-    let Some(current_chat) = app.current_chat_mut() else {
-        return;
-    };
+    let current_chat = app.current_chat_mut();
     current_chat.vertical_scroll = current_chat.vertical_scroll.saturating_sub(2);
     current_chat.vertical_scroll_state = current_chat
         .vertical_scroll_state
@@ -12,9 +10,7 @@ pub fn scroll_up(app: &mut App) {
 }
 
 pub fn scroll_down(app: &mut App) {
-    let Some(current_chat) = app.current_chat_mut() else {
-        return;
-    };
+    let current_chat = app.current_chat_mut();
     current_chat.vertical_scroll = current_chat.vertical_scroll.saturating_add(2);
     current_chat.vertical_scroll_state = current_chat
         .vertical_scroll_state
@@ -26,10 +22,7 @@ pub fn scroll_down(app: &mut App) {
 pub fn scroll_end(app: &mut App) {
     let max_lines_in_area = app.chat_messages_max_lines.saturating_sub(2);
 
-    let Some(current_chat) = app.current_chat_mut() else {
-        tracing::error!("No current chat to scroll to end");
-        return;
-    };
+    let current_chat = app.current_chat_mut();
     let scroll_position = current_chat
         .num_lines
         .saturating_sub(max_lines_in_area as usize);

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -240,10 +240,16 @@ impl App<'_> {
             chat.transition(ChatState::Loading);
         }
 
+        let repository = self
+            .current_chat()
+            .and_then(|chat| chat.repository.as_ref())
+            .cloned();
+
         let event = CommandEvent::builder()
             .command(cmd)
             .uuid(uuid)
             .responder(self.command_responder.for_chat_id(uuid))
+            .repository(repository)
             .build()
             .expect("Infallible; Failed to build command event");
 

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -739,4 +739,16 @@ mod tests {
         let chat = app.current_chat();
         assert!(chat.messages.contains(&message));
     }
+
+    #[tokio::test]
+    async fn test_cannot_delete_last_chat() {
+        let (repository, _guard) = test_repository();
+        let repository = Arc::new(repository);
+        let mut app = App::default_from_repository(repository.clone());
+
+        actions::delete_chat(&mut app);
+
+        assert_eq!(app.chats.len(), 1);
+        assert_eq!(app.current_chat().messages.len(), 1);
+    }
 }

--- a/src/frontend/app.rs
+++ b/src/frontend/app.rs
@@ -150,6 +150,7 @@ fn new_text_area() -> TextArea<'static> {
 }
 
 impl App<'_> {
+    #[must_use]
     pub fn default_from_repository(repository: Arc<Repository>) -> Self {
         let (ui_tx, ui_rx) = mpsc::unbounded_channel();
 
@@ -710,7 +711,7 @@ mod tests {
     async fn test_current_chat() {
         let (repository, _guard) = test_repository();
         let repository = Arc::new(repository);
-        let mut app = App::default_from_repository(repository.clone());
+        let app = App::default_from_repository(repository.clone());
         assert_eq!(app.current_chat().uuid, app.current_chat_uuid);
     }
 

--- a/src/frontend/chat_mode/chat_messages_widget.rs
+++ b/src/frontend/chat_mode/chat_messages_widget.rs
@@ -10,9 +10,7 @@ pub struct ChatMessagesWidget;
 impl ChatMessagesWidget {
     pub fn render(f: &mut ratatui::Frame, app: &mut App, area: Rect) {
         let num_chats = app.chats.len();
-        let Some(current_chat) = app.current_chat_mut() else {
-            return;
-        };
+        let current_chat = app.current_chat_mut();
         let mut messages = current_chat.messages.clone();
 
         if messages.is_empty() && num_chats == 1 {

--- a/src/frontend/chat_mode/input_bar_widget.rs
+++ b/src/frontend/chat_mode/input_bar_widget.rs
@@ -20,8 +20,8 @@ impl InputBarWidget {
             .padding(Padding::horizontal(1))
             .borders(Borders::ALL);
 
-        if app.current_chat().is_some_and(Chat::is_loading) {
-            let loading_msg = match &app.current_chat().expect("infallible").state {
+        if app.current_chat().is_loading() {
+            let loading_msg = match &app.current_chat().state {
                 ChatState::Loading => "Kwaaking ...".to_string(),
                 ChatState::LoadingWithMessage(msg) => format!("Kwaaking ({msg}) ..."),
                 ChatState::Ready => unreachable!(),

--- a/src/frontend/chat_mode/input_bar_widget.rs
+++ b/src/frontend/chat_mode/input_bar_widget.rs
@@ -1,7 +1,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Padding};
 
-use crate::chat::{Chat, ChatState};
+use crate::chat::ChatState;
 use crate::frontend::App;
 
 pub struct InputBarWidget;

--- a/src/frontend/chat_mode/message_formatting.rs
+++ b/src/frontend/chat_mode/message_formatting.rs
@@ -221,7 +221,7 @@ fn get_value<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chat_message::ChatRole;
+    use crate::{chat_message::ChatRole, test_utils::test_repository};
     use ratatui::text::Span;
 
     #[test]
@@ -246,7 +246,8 @@ mod tests {
 
     #[test]
     fn test_format_chat_message() {
-        let chat = Chat::default();
+        let (repository, _guard) = test_repository();
+        let chat = Chat::from_repository(repository.into());
         let message = ChatMessage::new_user("Hello, world!");
 
         let formatted_message = format_chat_message(&chat, &message);

--- a/src/frontend/chat_mode/ui.rs
+++ b/src/frontend/chat_mode/ui.rs
@@ -57,14 +57,12 @@ pub fn ui(f: &mut ratatui::Frame, area: Rect, app: &mut App) {
     HelpSectionWidget::render(f, app, help_area);
 
     // Bottom paragraph with the uuid and git branch, right aligned italic
-    let branch_name = if let Some(current_chat) = app.current_chat() {
-        current_chat
-            .branch_name
-            .as_deref()
-            .unwrap_or("not yet named")
-    } else {
-        "not yet named"
-    };
+    let branch_name = app
+        .current_chat()
+        .branch_name
+        .as_deref()
+        .unwrap_or("not yet named");
+
     Paragraph::new(Line::from(vec![Span::raw(format!(
         "uuid: {}   branch-name: {}",
         app.current_chat_uuid, branch_name

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ use git::github::GithubSession;
 use kwaak::evaluations;
 use kwaak::{
     agent::{self, session::start_mcp_toolboxes},
-    chat::Chat,
     cli, commands, config, frontend, git,
     indexing::{self, index_repository, DuckdbIndex},
     onboarding, repository, storage,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use git::github::GithubSession;
 use kwaak::evaluations;
 use kwaak::{
     agent::{self, session::start_mcp_toolboxes},
+    chat::Chat,
     cli, commands, config, frontend, git,
     indexing::{self, index_repository, DuckdbIndex},
     onboarding, repository, storage,
@@ -281,11 +282,13 @@ async fn start_tui(repository: repository::Repository, args: &cli::Args) -> Resu
 
     // Start the application
     let repository = Arc::new(repository);
-    let mut app = App::default();
+    let mut app = App::default_from_repository(repository.clone());
     app.ui_config = repository.config().ui.clone();
-    app.current_chat_mut()
-        .expect("app created with no chat")
-        .repository = Some(repository.clone());
+
+    debug_assert!(
+        app.chats.len() == 1,
+        "App should only have one chat at startup"
+    );
 
     if args.skip_indexing {
         app.skip_indexing = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
             cli::Commands::RunAgent { initial_message } => {
                 start_agent(repository, &initial_message, &args).await
             }
-            cli::Commands::Tui => start_tui(&repository, &args).await,
+            cli::Commands::Tui => start_tui(repository, &args).await,
             cli::Commands::ListTools => {
                 let github_session = Arc::new(GithubSession::from_repository(&repository)?);
                 let index = DuckdbIndex::default();
@@ -263,7 +263,7 @@ async fn start_agent(
 
 #[instrument(skip_all)]
 #[allow(clippy::field_reassign_with_default)]
-async fn start_tui(repository: &repository::Repository, args: &cli::Args) -> Result<()> {
+async fn start_tui(repository: repository::Repository, args: &cli::Args) -> Result<()> {
     ::tracing::info!("Loaded configuration: {:?}", repository.config());
 
     // Before starting the TUI, check if there is already a kwaak running on the project
@@ -280,6 +280,7 @@ async fn start_tui(repository: &repository::Repository, args: &cli::Args) -> Res
     let mut terminal = init_tui()?;
 
     // Start the application
+    let repository = Arc::new(repository);
     let mut app = App::default();
     app.ui_config = repository.config().ui.clone();
     app.current_chat_mut()
@@ -292,8 +293,7 @@ async fn start_tui(repository: &repository::Repository, args: &cli::Args) -> Res
 
     let app_result = {
         let kwaak_index = DuckdbIndex::default();
-        let mut handler =
-            commands::CommandHandler::from_repository_and_index(repository, kwaak_index);
+        let mut handler = commands::CommandHandler::from_index(kwaak_index);
         handler.register_ui(&mut app);
 
         let _guard = handler.start();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -255,7 +255,7 @@ macro_rules! assert_agent_responded {
 pub struct IntegrationContext {
     pub app: App<'static>,
     pub uuid: Uuid,
-    pub repository: Repository,
+    pub repository: Arc<Repository>,
     pub terminal: Terminal<TestBackend>,
     pub workdir: std::path::PathBuf,
 
@@ -279,7 +279,8 @@ impl IntegrationContext {
 pub async fn setup_integration() -> Result<IntegrationContext> {
     let (repository, repository_guard) = test_repository();
     let workdir = repository.path().clone();
-    let mut app = App::default().with_workdir(repository.path());
+    let repository = Arc::new(repository);
+    let mut app = App::default_from_repository(repository.clone()).with_workdir(repository.path());
     let duckdb = storage::get_duckdb(&repository);
     duckdb.setup().await.unwrap();
     let terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
@@ -290,9 +291,7 @@ pub async fn setup_integration() -> Result<IntegrationContext> {
     let handler_guard = handler.start();
 
     let uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8").unwrap();
-    let Some(current_chat) = app.current_chat_mut() else {
-        panic!("No current chat");
-    };
+    let current_chat = app.current_chat_mut();
 
     // Force to fixed uuid so that snapshots are stable
     current_chat.uuid = uuid;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -285,7 +285,7 @@ pub async fn setup_integration() -> Result<IntegrationContext> {
     let terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
 
     let index = DuckdbIndex::default();
-    let mut handler = CommandHandler::from_repository_and_index(repository.clone(), index);
+    let mut handler = CommandHandler::from_index(index);
     handler.register_ui(&mut app);
     let handler_guard = handler.start();
 

--- a/tests/diff_commands.rs
+++ b/tests/diff_commands.rs
@@ -67,16 +67,12 @@ async fn test_diff() {
     let current_branch = git::util::main_branch(&workdir);
     assert_eq!(&current_branch, &repository.config().git.main_branch);
 
-    let branch_name = if let Some(chat) = app.current_chat() {
-        chat.branch_name.clone().expect("branch not yet named")
-    } else {
-        panic!("No current chat");
-    };
+    let branch_name = app.current_chat().branch_name.as_deref().unwrap();
 
     // Now let's check out the branch and verify we have the hello.txt
     let output = tokio::process::Command::new("git")
         .arg("checkout")
-        .arg(&branch_name)
+        .arg(branch_name)
         .current_dir(&workdir)
         .output()
         .await


### PR DESCRIPTION
Requires all commands needing it to include a repository in their command event. A repository is fully serializable (pure config), so this should be fine.

This makes it possible in the future to have different chat sessions with different repositories or run the command handler in a server.
