### PR TITLE
fix: filter out empty messages in copy_last_message function

### DIFF
--- a/src/frontend/actions/mod.rs
+++ b/src/frontend/actions/mod.rs
@@ -42,7 +42,9 @@ pub fn copy_last_message(app: &mut App) {
         .and_then(|c| {
             c.messages
                 .iter()
-                .filter(|m| m.role().is_assistant() || m.role().is_user())
+                .filter(|m| {
+                    (m.role().is_assistant() || m.role().is_user()) && !m.content().is_empty()
+                })
                 .next_back()
         })
         .map(ChatMessage::content)


### PR DESCRIPTION
Issue turned out to be simple. Since we now always rely on the agent to call `stop`, the last message might be empty. This fix makes sure it uses the last message with actual content.

Fixes #472